### PR TITLE
atropos: Remove static libclang dependency

### DIFF
--- a/tools/sched_ext/atropos/Cargo.toml
+++ b/tools/sched_ext/atropos/Cargo.toml
@@ -21,7 +21,7 @@ ordered-float = "3.4.0"
 simplelog = "0.12.0"
 
 [build-dependencies]
-bindgen = { version = "0.61.0", features = ["logging", "static"], default-features = false }
+bindgen = { version = "0.61.0" }
 libbpf-cargo = "0.13.0"
 
 [features]


### PR DESCRIPTION
Most distributions provide a shared lib version of libclang, so building atropos is not as easy as it should be. #6 is an example of this being confusing to other developers.

We have no particular dependency on libclang being static, so this can be configured more conventionally.