### PR TITLE
scx: Auto-release example scheduler struct_ops on program exit

### DIFF
--- a/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
+++ b/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
@@ -723,7 +723,7 @@ void BPF_STRUCT_OPS(atropos_exit, struct scx_exit_info *ei)
 	exit_type = ei->type;
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops atropos = {
 	.select_cpu = (void *)atropos_select_cpu,
 	.enqueue = (void *)atropos_enqueue,

--- a/tools/sched_ext/scx_example_central.bpf.c
+++ b/tools/sched_ext/scx_example_central.bpf.c
@@ -314,7 +314,7 @@ void BPF_STRUCT_OPS(central_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops central_ops = {
 	/*
 	 * We are offloading all scheduling decisions to the central CPU and

--- a/tools/sched_ext/scx_example_flatcg.bpf.c
+++ b/tools/sched_ext/scx_example_flatcg.bpf.c
@@ -853,7 +853,7 @@ void BPF_STRUCT_OPS(fcg_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops flatcg_ops = {
 	.enqueue		= (void *)fcg_enqueue,
 	.dispatch		= (void *)fcg_dispatch,

--- a/tools/sched_ext/scx_example_pair.bpf.c
+++ b/tools/sched_ext/scx_example_pair.bpf.c
@@ -613,7 +613,7 @@ void BPF_STRUCT_OPS(pair_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops pair_ops = {
 	.enqueue		= (void *)pair_enqueue,
 	.dispatch		= (void *)pair_dispatch,

--- a/tools/sched_ext/scx_example_qmap.bpf.c
+++ b/tools/sched_ext/scx_example_qmap.bpf.c
@@ -384,7 +384,7 @@ void BPF_STRUCT_OPS(qmap_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops qmap_ops = {
 	.select_cpu		= (void *)qmap_select_cpu,
 	.enqueue		= (void *)qmap_enqueue,

--- a/tools/sched_ext/scx_example_simple.bpf.c
+++ b/tools/sched_ext/scx_example_simple.bpf.c
@@ -117,7 +117,7 @@ void BPF_STRUCT_OPS(simple_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops simple_ops = {
 	.enqueue		= (void *)simple_enqueue,
 	.running		= (void *)simple_running,

--- a/tools/sched_ext/scx_example_userland.bpf.c
+++ b/tools/sched_ext/scx_example_userland.bpf.c
@@ -249,7 +249,7 @@ void BPF_STRUCT_OPS(userland_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops userland_ops = {
 	.select_cpu		= (void *)userland_select_cpu,
 	.enqueue		= (void *)userland_enqueue,


### PR DESCRIPTION
When a BPF scheduler user-space program exits, the struct_ops map that it attaches to to load the BPF program is not automatically detached. This can cause the map and progs to remain loaded, which in turn will cause future attempts to load a new scheduling program to fail.

In commit 8d1608d70927 ("libbpf: Create a bpf_link in bpf_map__attach_struct_ops()"), Kui-feng updated
bpf_map__attach_struct_ops() to create an actual link for the struct_ops map, which in turn makes it automatically close the map when the owning program exits. This patch updates the example schedulers to leverage this by updating their sections to SEC(".struct_ops.link").