### PR TITLE
Add proper support for auto-detach in sched_ext

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3555,6 +3555,23 @@ static int bpf_scx_init(struct btf *btf)
 	return 0;
 }
 
+static int bpf_scx_update(void *kdata, void *old_kdata)
+{
+	/*
+	 * sched_ext does not support updating the actively-loaded BPF
+	 * scheduler, as registering a BPF scheduler can always fail if the
+	 * scheduler returns an error code for e.g. ops.init(),
+	 * ops.prep_enable(), etc. Similarly, we can always race with
+	 * unregistration happening elsewhere, such as with sysrq.
+	 */
+	return -EOPNOTSUPP;
+}
+
+static int bpf_scx_validate(void *kdata)
+{
+	return 0;
+}
+
 /* "extern" to avoid sparse warning, only used in this file */
 extern struct bpf_struct_ops bpf_sched_ext_ops;
 
@@ -3565,6 +3582,8 @@ struct bpf_struct_ops bpf_sched_ext_ops = {
 	.check_member = bpf_scx_check_member,
 	.init_member = bpf_scx_init_member,
 	.init = bpf_scx_init,
+	.update = bpf_scx_update,
+	.validate = bpf_scx_validate,
 	.name = "sched_ext_ops",
 };
 

--- a/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
+++ b/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
@@ -723,7 +723,7 @@ void BPF_STRUCT_OPS(atropos_exit, struct scx_exit_info *ei)
 	exit_type = ei->type;
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops atropos = {
 	.select_cpu = (void *)atropos_select_cpu,
 	.enqueue = (void *)atropos_enqueue,

--- a/tools/sched_ext/scx_example_central.bpf.c
+++ b/tools/sched_ext/scx_example_central.bpf.c
@@ -314,7 +314,7 @@ void BPF_STRUCT_OPS(central_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops central_ops = {
 	/*
 	 * We are offloading all scheduling decisions to the central CPU and

--- a/tools/sched_ext/scx_example_flatcg.bpf.c
+++ b/tools/sched_ext/scx_example_flatcg.bpf.c
@@ -853,7 +853,7 @@ void BPF_STRUCT_OPS(fcg_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops flatcg_ops = {
 	.enqueue		= (void *)fcg_enqueue,
 	.dispatch		= (void *)fcg_dispatch,

--- a/tools/sched_ext/scx_example_pair.bpf.c
+++ b/tools/sched_ext/scx_example_pair.bpf.c
@@ -613,7 +613,7 @@ void BPF_STRUCT_OPS(pair_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops pair_ops = {
 	.enqueue		= (void *)pair_enqueue,
 	.dispatch		= (void *)pair_dispatch,

--- a/tools/sched_ext/scx_example_qmap.bpf.c
+++ b/tools/sched_ext/scx_example_qmap.bpf.c
@@ -384,7 +384,7 @@ void BPF_STRUCT_OPS(qmap_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops qmap_ops = {
 	.select_cpu		= (void *)qmap_select_cpu,
 	.enqueue		= (void *)qmap_enqueue,

--- a/tools/sched_ext/scx_example_simple.bpf.c
+++ b/tools/sched_ext/scx_example_simple.bpf.c
@@ -117,7 +117,7 @@ void BPF_STRUCT_OPS(simple_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops simple_ops = {
 	.enqueue		= (void *)simple_enqueue,
 	.running		= (void *)simple_running,

--- a/tools/sched_ext/scx_example_userland.bpf.c
+++ b/tools/sched_ext/scx_example_userland.bpf.c
@@ -249,7 +249,7 @@ void BPF_STRUCT_OPS(userland_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops")
+SEC(".struct_ops.link")
 struct sched_ext_ops userland_ops = {
 	.select_cpu		= (void *)userland_select_cpu,
 	.enqueue		= (void *)userland_enqueue,


### PR DESCRIPTION
When a BPF scheduler user-space program exits, the struct_ops map that                                                                                                                        
it attaches to to load the BPF program is not automatically detached.                                                                                                                         
This can cause the map and progs to remain loaded, which in turn will                                                                                                                         
cause future attempts to load a new scheduling program to fail.                                                                                                                               
                                                                                                                                                                                              
In commit 8d1608d70927 ("libbpf: Create a bpf_link in                                                                                                                                         
bpf_map__attach_struct_ops()"), Kui-feng updated                                                                                                                                              
bpf_map__attach_struct_ops() to create an actual link for the struct_ops                                                                                                                      
map, which in turn makes it automatically close the map when the owning                                                                                                                       
program exits. This patch updates the example schedulers to leverage                                                                                                                          
this by updating their sections to SEC(".struct_ops.link").

When I originally tried to do this, I neglected to actually update the core
ext.c code to support linked struct_ops. This set now includes the necessary
changes to those files, so #12 shouldn't happen again (and I tested all of
the schedulers to verify that it does not).