### PR TITLE
scx: Remove unnecessary pr_err on ops.prep_enable() failure path

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3272,8 +3272,6 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 			spin_lock_irq(&scx_tasks_lock);
 			scx_task_iter_exit(&sti);
 			spin_unlock_irq(&scx_tasks_lock);
-			pr_err("sched_ext: ops.prep_enable() failed (%d) for %s[%d] while loading\n",
-			       ret, p->comm, p->pid);
 			goto err_disable_unlock;
 		}
 


### PR DESCRIPTION
When ops.prep_enable() returns an error code that is propagated through scx_ops_prepare_task(), we currently issue a pr_err from scx_ops_enable(). It seems wrong for a BPF prog to be able to cause the kernel to issue a pr_err message, and we already capture the error in an ops_sanitizer_err() call in scx_ops_prepare_task(). Let's remove it.