### PR TITLE
use resizing of datasec maps in examples

### DIFF
--- a/tools/sched_ext/scx_central.c
+++ b/tools/sched_ext/scx_central.c
@@ -63,6 +63,10 @@ int main(int argc, char **argv)
 		}
 	}
 
+	/* Resize arrays so their element count is equal to cpu count. */
+	RESIZE_ARRAY(data, cpu_gimme_task, skel->rodata->nr_cpu_ids);
+	RESIZE_ARRAY(data, cpu_started_at, skel->rodata->nr_cpu_ids);
+
 	SCX_BUG_ON(scx_central__load(skel), "Failed to load skel");
 
 	link = bpf_map__attach_struct_ops(skel->maps.central_ops);

--- a/tools/sched_ext/scx_common.bpf.h
+++ b/tools/sched_ext/scx_common.bpf.h
@@ -82,6 +82,26 @@ SEC("struct_ops.s/"#name)							\
 BPF_PROG(name, ##args)
 
 /**
+ * RESIZABLE_ARRAY - Generates annotations for an array that may be resized
+ * @elfsec: the data section of the BPF program in which to place the array
+ * @arr: the name of the array
+ *
+ * libbpf has an API for setting map value sizes. Since data sections (i.e.
+ * bss, data, rodata) themselves are maps, a data section can be resized. If
+ * a data section has an array as its last element, the BTF info for that
+ * array will be adjusted so that length of the array is extended to meet the
+ * new length of the data section. This macro annotates an array to have an
+ * element count of one with the assumption that this array can be resized
+ * within the userspace program. It also annotates the section specifier so
+ * this array exists in a custom sub data section which can be resized
+ * independently.
+ *
+ * See RESIZE_ARRAY() for the userspace convenience macro for resizing an
+ * array declared with RESIZABLE_ARRAY().
+ */
+#define RESIZABLE_ARRAY(elfsec, arr) arr[1] SEC("."#elfsec"."#arr)
+
+/**
  * MEMBER_VPTR - Obtain the verified pointer to a struct or array member
  * @base: struct or array to index
  * @member: dereferenced member (e.g. ->field, [idx0][idx1], ...)
@@ -115,6 +135,34 @@ BPF_PROG(name, ##args)
 		: "r"(__base),							\
 		  [max]"i"(sizeof(base) - sizeof(base member)));		\
 	__addr;									\
+})
+
+/**
+ * ARRAY_ELEM_PTR - Obtain the verified pointer to an array element
+ * @arr: array to index into
+ * @i: array index
+ * @n: number of elements in array
+ *
+ * Similar to MEMBER_VPTR() but is intended for use with arrays where the
+ * element count needs to be explicit.
+ * It can be used in cases where a global array is defined with an initial
+ * size but is intended to be be resized before loading the BPF program.
+ * Without this version of the macro, MEMBER_VPTR() will use the compile time
+ * size of the array to compute the max, which will result in rejection by
+ * the verifier.
+ */
+#define ARRAY_ELEM_PTR(arr, i, n) (typeof(arr[i]) *)({	  \
+	u64 __base = (u64)arr;				  \
+	u64 __addr = (u64)&(arr[i]) - __base;		  \
+	asm volatile (					  \
+		"if %0 <= %[max] goto +2\n"		  \
+		"%0 = 0\n"				  \
+		"goto +1\n"				  \
+		"%0 += %1\n"				  \
+		: "+r"(__addr)				  \
+		: "r"(__base),				  \
+		  [max]"r"(sizeof(arr[0]) * ((n) - 1)));  \
+	__addr;						  \
 })
 
 /*

--- a/tools/sched_ext/scx_pair.h
+++ b/tools/sched_ext/scx_pair.h
@@ -2,7 +2,6 @@
 #define __SCX_EXAMPLE_PAIR_H
 
 enum {
-	MAX_CPUS		= 4096,
 	MAX_QUEUED		= 4096,
 	MAX_CGRPS		= 4096,
 };

--- a/tools/sched_ext/scx_user_common.h
+++ b/tools/sched_ext/scx_user_common.h
@@ -31,4 +31,27 @@
 			SCX_BUG((__fmt) __VA_OPT__(,) __VA_ARGS__);	\
 	} while (0)
 
+/**
+ * RESIZE_ARRAY - Convenience macro for resizing a BPF array
+ * @elfsec: the data section of the BPF program in which to the array exists
+ * @arr: the name of the array
+ * @n: the desired array element count
+ *
+ * For BPF arrays declared with RESIZABLE_ARRAY(), this macro performs two
+ * operations. It resizes the map which corresponds to the custom data
+ * section that contains the target array. As a side effect, the BTF info for
+ * the array is adjusted so that the array length is sized to cover the new
+ * data section size. The second operation is reassigning the skeleton pointer
+ * for that custom data section so that it points to the newly memory mapped
+ * region.
+ */
+#define RESIZE_ARRAY(elfsec, arr, n)						  \
+	do {									  \
+		size_t __sz;							  \
+		bpf_map__set_value_size(skel->maps.elfsec##_##arr,		  \
+				sizeof(skel->elfsec##_##arr->arr[0]) * (n));	  \
+		skel->elfsec##_##arr =						  \
+			bpf_map__initial_value(skel->maps.elfsec##_##arr, &__sz); \
+	} while (0)
+
 #endif	/* __SCHED_EXT_USER_COMMON_H */


### PR DESCRIPTION
there are some percpu arrays in the example schedulers that can make use of a recent libbpf feature that allows for resizing global data sections. for select arrays, they can be placed in custom named data sections and then resized to match the actual cpu count on a given host.

shown below is the BTF dump of the central and pair example scheduler programs that shows the array lengths have changed (nr_elements) to match the 12-cpu host they were tested on. note the linkage has also changed. this is a result of making the arrays non-static which was needed to access them through the skeleton for resizing in the userspace program.

central_dispatch before:
[742] ARRAY '(anon)' type_id=97 index_type_id=4 nr_elems=4096
[743] VAR 'cpu_gimme_task' type_id=742, linkage=static
[744] ARRAY '(anon)' type_id=53 index_type_id=4 nr_elems=4096
[745] VAR 'cpu_started_at' type_id=744, linkage=static

central_dispatch after:
[743] VAR 'cpu_gimme_task' type_id=867, linkage=global
[745] VAR 'cpu_started_at' type_id=868, linkage=global
[867] ARRAY '(anon)' type_id=97 index_type_id=4 nr_elems=12
[868] ARRAY '(anon)' type_id=53 index_type_id=4 nr_elems=12

pair_dispatch before:
[675] ARRAY '(anon)' type_id=673 index_type_id=4 nr_elems=4096
[676] VAR 'pair_cpu' type_id=675, linkage=global
[733] ARRAY '(anon)' type_id=669 index_type_id=4 nr_elems=4096
[734] VAR 'pair_id' type_id=733, linkage=global
[735] VAR 'in_pair_idx' type_id=733, linkage=global

pair_dispatch after:
[730] VAR 'pair_cpu' type_id=890, linkage=global
[732] VAR 'pair_id' type_id=891, linkage=global
[733] VAR 'in_pair_idx' type_id=892, linkage=global
[890] ARRAY '(anon)' type_id=727 index_type_id=4 nr_elems=12
[891] ARRAY '(anon)' type_id=667 index_type_id=4 nr_elems=12
[892] ARRAY '(anon)' type_id=667 index_type_id=4 nr_elems=12

the existing MEMBER_VPTR() macro was no longer applicable to use on these select arrays, because it uses the compile-time length so it caused verification failures when attempting to access an array element at an index greater than the initial size. a variation on this macro was added that accepts a size argument in order to match the newly resized arrays.