### PR TITLE
Bug fixes and a lot of atropos updates

### DIFF
--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -366,7 +366,6 @@ struct sched_ext_ops {
 	 * - scx_bpf_select_cpu_dfl()
 	 * - scx_bpf_test_and_clear_cpu_idle()
 	 * - scx_bpf_pick_idle_cpu()
-	 * - scx_bpf_any_idle_cpu()
 	 *
 	 * The user also must implement ops.select_cpu() as the default
 	 * implementation relies on scx_bpf_select_cpu_dfl().

--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -370,8 +370,8 @@ struct sched_ext_ops {
 	 * The user also must implement ops.select_cpu() as the default
 	 * implementation relies on scx_bpf_select_cpu_dfl().
 	 *
-	 * If you keep the built-in idle tracking, specify the
-	 * %SCX_OPS_KEEP_BUILTIN_IDLE flag.
+	 * Specify the %SCX_OPS_KEEP_BUILTIN_IDLE flag to keep the built-in idle
+	 * tracking.
 	 */
 	void (*update_idle)(s32 cpu, bool idle);
 

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -3954,6 +3954,16 @@ bool cpus_share_cache(int this_cpu, int that_cpu)
 
 static inline bool ttwu_queue_cond(struct task_struct *p, int cpu)
 {
+#ifdef CONFIG_SCHED_CLASS_EXT
+	/*
+	 * The BPF scheduler may depend on select_task_rq() being invoked during
+	 * wakeups and @p may end up executing on a different CPU regardless of
+	 * what happens in the wakeup path making the ttwu_queue optimization
+	 * ineffective. Skip if on SCX.
+	 */
+	if (p->sched_class == &ext_sched_class)
+		return false;
+#endif
 	/*
 	 * Do not complicate things with the async wake_list while the CPU is
 	 * in hotplug state.

--- a/kernel/sched/ext.h
+++ b/kernel/sched/ext.h
@@ -91,6 +91,10 @@ enum scx_kick_flags {
 	SCX_KICK_WAIT		= 1LLU << 1,	/* wait for the CPU to be rescheduled */
 };
 
+enum scx_pick_idle_cpu_flags {
+	SCX_PICK_IDLE_CPU_WHOLE	= 1LLU << 0,	/* pick a CPU whose SMT siblings are also idle */
+};
+
 #ifdef CONFIG_SCHED_CLASS_EXT
 
 extern const struct sched_class ext_sched_class;

--- a/tools/sched_ext/atropos/Cargo.toml
+++ b/tools/sched_ext/atropos/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1.0.65"
 bitvec = { version = "1.0", features = ["serde"] }
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
-fb_procfs = { git = "https://github.com/facebookincubator/below.git", rev = "f305730"}
 hex = "0.4.3"
 libbpf-rs = "0.19.1"
 libbpf-sys = { version = "1.0.4", features = ["novendor", "static"] }

--- a/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
+++ b/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
@@ -469,6 +469,7 @@ void BPF_STRUCT_OPS(atropos_runnable, struct task_struct *p, u64 enq_flags)
 	}
 
 	task_ctx->runnable_at = bpf_ktime_get_ns();
+	task_ctx->is_kworker = p->flags & PF_WQ_WORKER;
 }
 
 void BPF_STRUCT_OPS(atropos_running, struct task_struct *p)

--- a/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
+++ b/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
@@ -144,6 +144,20 @@ static inline bool vtime_before(u64 a, u64 b)
 	return (s64)(a - b) < 0;
 }
 
+static u32 cpu_to_dom_id(s32 cpu)
+{
+	const volatile u32 *dom_idp;
+
+	if (nr_doms <= 1)
+		return 0;
+
+	dom_idp = MEMBER_VPTR(cpu_dom_id_map, [cpu]);
+	if (!dom_idp)
+		return MAX_DOMS;
+
+	return *dom_idp;
+}
+
 static bool task_set_domain(struct task_ctx *task_ctx, struct task_struct *p,
 			    u32 new_dom_id)
 {
@@ -360,20 +374,6 @@ void BPF_STRUCT_OPS(atropos_enqueue, struct task_struct *p, u64 enq_flags)
 		scx_bpf_dispatch_vtime(p, task_ctx->dom_id, slice_ns, vtime,
 				       enq_flags);
 	}
-}
-
-static u32 cpu_to_dom_id(s32 cpu)
-{
-	const volatile u32 *dom_idp;
-
-	if (nr_doms <= 1)
-		return 0;
-
-	dom_idp = MEMBER_VPTR(cpu_dom_id_map, [cpu]);
-	if (!dom_idp)
-		return MAX_DOMS;
-
-	return *dom_idp;
 }
 
 static bool cpumask_intersects_domain(const struct cpumask *cpumask, u32 dom_id)

--- a/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
+++ b/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
@@ -484,7 +484,7 @@ s32 BPF_STRUCT_OPS(atropos_select_cpu, struct task_struct *p, s32 prev_cpu,
 	if (prev_domestic)
 		cpu = prev_cpu;
 	else
-		cpu = bpf_cpumask_any((const struct cpumask *)p_cpumask);
+		cpu = scx_bpf_pick_any_cpu((const struct cpumask *)p_cpumask, 0);
 
 	scx_bpf_put_idle_cpumask(idle_smtmask);
 	return cpu;
@@ -552,9 +552,7 @@ void BPF_STRUCT_OPS(atropos_enqueue, struct task_struct *p, u64 enq_flags)
 	 * stalls. Kick a domestic CPU if @p is on a foreign domain.
 	 */
 	if (!bpf_cpumask_test_cpu(scx_bpf_task_cpu(p), (const struct cpumask *)p_cpumask)) {
-		cpu = scx_bpf_pick_idle_cpu((const struct cpumask *)p_cpumask, 0);
-		if (cpu < 0)
-			cpu = bpf_cpumask_any((const struct cpumask *)p_cpumask);
+		cpu = scx_bpf_pick_any_cpu((const struct cpumask *)p_cpumask, 0);
 		scx_bpf_kick_cpu(cpu, 0);
 		stat_add(ATROPOS_STAT_REPATRIATE, 1);
 	}

--- a/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
+++ b/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
@@ -74,11 +74,14 @@ const volatile __u64 slice_ns = SCX_SLICE_DFL;
 int exit_type = SCX_EXIT_NONE;
 char exit_msg[SCX_EXIT_MSG_LEN];
 
+/*
+ * Per-CPU context
+ */
 struct pcpu_ctx {
 	__u32 dom_rr_cur; /* used when scanning other doms */
 
 	/* libbpf-rs does not respect the alignment, so pad out the struct explicitly */
-	__u8 _padding[CACHELINE_SIZE - sizeof(u64)];
+	__u8 _padding[CACHELINE_SIZE - sizeof(u32)];
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 struct pcpu_ctx pcpu_ctx[MAX_CPUS];

--- a/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
+++ b/tools/sched_ext/atropos/src/bpf/atropos.bpf.c
@@ -275,7 +275,7 @@ s32 BPF_STRUCT_OPS(atropos_select_cpu, struct task_struct *p, int prev_cpu,
 		return -ENOENT;
 
 	/* If there is an eligible idle CPU, dispatch directly */
-	cpu = scx_bpf_pick_idle_cpu((const struct cpumask *)p_cpumask);
+	cpu = scx_bpf_pick_idle_cpu((const struct cpumask *)p_cpumask, 0);
 	if (cpu >= 0) {
 		stat_add(ATROPOS_STAT_DIRECT_DISPATCH, 1);
 		goto local;
@@ -332,7 +332,7 @@ void BPF_STRUCT_OPS(atropos_enqueue, struct task_struct *p, u32 enq_flags)
 			scx_bpf_error("Failed to get task_ctx->cpumask");
 			return;
 		}
-		cpu = scx_bpf_pick_idle_cpu((const struct cpumask *)p_cpumask);
+		cpu = scx_bpf_pick_idle_cpu((const struct cpumask *)p_cpumask, 0);
 
 		if (cpu >= 0)
 			scx_bpf_kick_cpu(cpu, 0);

--- a/tools/sched_ext/atropos/src/bpf/atropos.h
+++ b/tools/sched_ext/atropos/src/bpf/atropos.h
@@ -45,6 +45,7 @@ struct task_ctx {
 	unsigned long long runnable_at;
 	unsigned long long runnable_for;
 	bool dispatch_local;
+	bool is_kworker;
 };
 
 #endif /* __ATROPOS_H */

--- a/tools/sched_ext/atropos/src/bpf/atropos.h
+++ b/tools/sched_ext/atropos/src/bpf/atropos.h
@@ -19,15 +19,20 @@
 
 /* Statistics */
 enum stat_idx {
-	ATROPOS_STAT_TASK_GET_ERR,
+	/* The following fields add up to all dispatched tasks */
 	ATROPOS_STAT_WAKE_SYNC,
 	ATROPOS_STAT_PREV_IDLE,
 	ATROPOS_STAT_PINNED,
 	ATROPOS_STAT_DIRECT_DISPATCH,
 	ATROPOS_STAT_DSQ_DISPATCH,
 	ATROPOS_STAT_GREEDY,
+
+	/* Extra stats that don't contribute to total */
 	ATROPOS_STAT_LOAD_BALANCE,
-	ATROPOS_STAT_LAST_TASK,
+
+	/* Errors */
+	ATROPOS_STAT_TASK_GET_ERR,
+
 	ATROPOS_NR_STATS,
 };
 

--- a/tools/sched_ext/atropos/src/bpf/atropos.h
+++ b/tools/sched_ext/atropos/src/bpf/atropos.h
@@ -22,13 +22,17 @@ enum stat_idx {
 	/* The following fields add up to all dispatched tasks */
 	ATROPOS_STAT_WAKE_SYNC,
 	ATROPOS_STAT_PREV_IDLE,
+	ATROPOS_STAT_GREEDY_IDLE,
 	ATROPOS_STAT_PINNED,
 	ATROPOS_STAT_DIRECT_DISPATCH,
+	ATROPOS_STAT_DIRECT_GREEDY,
+	ATROPOS_STAT_DIRECT_GREEDY_FAR,
 	ATROPOS_STAT_DSQ_DISPATCH,
 	ATROPOS_STAT_GREEDY,
 
 	/* Extra stats that don't contribute to total */
 	ATROPOS_STAT_REPATRIATE,
+	ATROPOS_STAT_KICK_GREEDY,
 	ATROPOS_STAT_LOAD_BALANCE,
 
 	/* Errors */
@@ -38,14 +42,23 @@ enum stat_idx {
 };
 
 struct task_ctx {
-	unsigned long long dom_mask; /* the domains this task can run on */
+	/* The domains this task can run on */
+	unsigned long long dom_mask;
+
 	struct bpf_cpumask __kptr *cpumask;
 	unsigned int dom_id;
 	unsigned int weight;
 	unsigned long long runnable_at;
 	unsigned long long runnable_for;
-	bool dispatch_local;
+
+	/* The task is a workqueue worker thread */
 	bool is_kworker;
+
+	/* Allowed on all CPUs and eligible for DIRECT_GREEDY optimization */
+	bool all_cpus;
+
+	/* select_cpu() telling enqueue() to queue directly on the DSQ */
+	bool dispatch_local;
 };
 
 #endif /* __ATROPOS_H */

--- a/tools/sched_ext/atropos/src/bpf/atropos.h
+++ b/tools/sched_ext/atropos/src/bpf/atropos.h
@@ -28,6 +28,7 @@ enum stat_idx {
 	ATROPOS_STAT_GREEDY,
 
 	/* Extra stats that don't contribute to total */
+	ATROPOS_STAT_REPATRIATE,
 	ATROPOS_STAT_LOAD_BALANCE,
 
 	/* Errors */

--- a/tools/sched_ext/atropos/src/main.rs
+++ b/tools/sched_ext/atropos/src/main.rs
@@ -811,8 +811,7 @@ impl<'a> Scheduler<'a> {
             + stat(atropos_sys::stat_idx_ATROPOS_STAT_PINNED)
             + stat(atropos_sys::stat_idx_ATROPOS_STAT_DIRECT_DISPATCH)
             + stat(atropos_sys::stat_idx_ATROPOS_STAT_DSQ_DISPATCH)
-            + stat(atropos_sys::stat_idx_ATROPOS_STAT_GREEDY)
-            + stat(atropos_sys::stat_idx_ATROPOS_STAT_LAST_TASK);
+            + stat(atropos_sys::stat_idx_ATROPOS_STAT_GREEDY);
 
         info!(
             "cpu={:7.2} bal={} load_avg={:8.2} task_err={} lb_data_err={} proc={:?}ms",

--- a/tools/sched_ext/atropos/src/main.rs
+++ b/tools/sched_ext/atropos/src/main.rs
@@ -829,14 +829,19 @@ impl<'a> Scheduler<'a> {
         let stat_pct = |idx| stat(idx) as f64 / total as f64 * 100.0;
 
         info!(
-            "tot={:7} wsync={:5.2} prev_idle={:5.2} pin={:5.2} dir={:5.2} dsq={:5.2} greedy={:5.2}",
+            "tot={:7} wsync={:5.2} prev_idle={:5.2} pin={:5.2} dir={:5.2}",
             total,
             stat_pct(atropos_sys::stat_idx_ATROPOS_STAT_WAKE_SYNC),
             stat_pct(atropos_sys::stat_idx_ATROPOS_STAT_PREV_IDLE),
             stat_pct(atropos_sys::stat_idx_ATROPOS_STAT_PINNED),
             stat_pct(atropos_sys::stat_idx_ATROPOS_STAT_DIRECT_DISPATCH),
+        );
+
+        info!(
+            "dsq={:5.2} greedy={:5.2} rep={:5.2}",
             stat_pct(atropos_sys::stat_idx_ATROPOS_STAT_DSQ_DISPATCH),
             stat_pct(atropos_sys::stat_idx_ATROPOS_STAT_GREEDY),
+            stat_pct(atropos_sys::stat_idx_ATROPOS_STAT_REPATRIATE),
         );
 
         for i in 0..self.nr_doms {

--- a/tools/sched_ext/atropos/src/main.rs
+++ b/tools/sched_ext/atropos/src/main.rs
@@ -41,7 +41,7 @@ use ordered_float::OrderedFloat;
 /// chiplet in a six-chiplet AMD processor, and could match the performance of
 /// production setup using CFS.
 ///
-/// WARNING: Atropos currenlty assumes that all domains have equal
+/// WARNING: Atropos currently assumes that all domains have equal
 /// processing power and at similar distances from each other. This
 /// limitation will be removed in the future.
 #[derive(Debug, Parser)]

--- a/tools/sched_ext/scx_common.bpf.h
+++ b/tools/sched_ext/scx_common.bpf.h
@@ -61,7 +61,7 @@ void scx_bpf_dispatch_vtime(struct task_struct *p, u64 dsq_id, u64 slice, u64 vt
 void scx_bpf_kick_cpu(s32 cpu, u64 flags) __ksym;
 s32 scx_bpf_dsq_nr_queued(u64 dsq_id) __ksym;
 bool scx_bpf_test_and_clear_cpu_idle(s32 cpu) __ksym;
-s32 scx_bpf_pick_idle_cpu(const cpumask_t *cpus_allowed) __ksym;
+s32 scx_bpf_pick_idle_cpu(const cpumask_t *cpus_allowed, u64 flags) __ksym;
 const struct cpumask *scx_bpf_get_idle_cpumask(void) __ksym;
 const struct cpumask *scx_bpf_get_idle_smtmask(void) __ksym;
 void scx_bpf_put_idle_cpumask(const struct cpumask *cpumask) __ksym;

--- a/tools/sched_ext/scx_common.bpf.h
+++ b/tools/sched_ext/scx_common.bpf.h
@@ -63,6 +63,7 @@ void scx_bpf_kick_cpu(s32 cpu, u64 flags) __ksym;
 s32 scx_bpf_dsq_nr_queued(u64 dsq_id) __ksym;
 bool scx_bpf_test_and_clear_cpu_idle(s32 cpu) __ksym;
 s32 scx_bpf_pick_idle_cpu(const cpumask_t *cpus_allowed, u64 flags) __ksym;
+s32 scx_bpf_pick_any_cpu(const cpumask_t *cpus_allowed, u64 flags) __ksym;
 const struct cpumask *scx_bpf_get_idle_cpumask(void) __ksym;
 const struct cpumask *scx_bpf_get_idle_smtmask(void) __ksym;
 void scx_bpf_put_idle_cpumask(const struct cpumask *cpumask) __ksym;

--- a/tools/sched_ext/scx_common.bpf.h
+++ b/tools/sched_ext/scx_common.bpf.h
@@ -13,6 +13,7 @@
 #include <linux/errno.h>
 #include "user_exit_info.h"
 
+#define PF_WQ_WORKER			0x00000020	/* I'm a workqueue worker */
 #define PF_KTHREAD			0x00200000	/* I am a kernel thread */
 #define PF_EXITING			0x00000004
 #define CLOCK_MONOTONIC			1

--- a/tools/sched_ext/scx_example_qmap.bpf.c
+++ b/tools/sched_ext/scx_example_qmap.bpf.c
@@ -117,7 +117,7 @@ s32 BPF_STRUCT_OPS(qmap_select_cpu, struct task_struct *p,
 		return prev_cpu;
 	}
 
-	cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr);
+	cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
 	if (cpu >= 0)
 		return cpu;
 
@@ -191,7 +191,7 @@ void BPF_STRUCT_OPS(qmap_enqueue, struct task_struct *p, u64 enq_flags)
 		s32 cpu;
 
 		scx_bpf_dispatch(p, SCX_DSQ_GLOBAL, 0, enq_flags);
-		cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr);
+		cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
 		if (cpu >= 0)
 			scx_bpf_kick_cpu(cpu, 0);
 		return;

--- a/tools/sched_ext/scx_example_simple.bpf.c
+++ b/tools/sched_ext/scx_example_simple.bpf.c
@@ -105,6 +105,12 @@ void BPF_STRUCT_OPS(simple_stopping, struct task_struct *p, bool runnable)
 	p->scx.dsq_vtime += (SCX_SLICE_DFL - p->scx.slice) * 100 / p->scx.weight;
 }
 
+void BPF_STRUCT_OPS(simple_enable, struct task_struct *p,
+		    struct scx_enable_args *args)
+{
+	p->scx.dsq_vtime = vtime_now;
+}
+
 s32 BPF_STRUCT_OPS(simple_init)
 {
 	if (!switch_partial)
@@ -122,6 +128,7 @@ struct sched_ext_ops simple_ops = {
 	.enqueue		= (void *)simple_enqueue,
 	.running		= (void *)simple_running,
 	.stopping		= (void *)simple_stopping,
+	.enable			= (void *)simple_enable,
 	.init			= (void *)simple_init,
 	.exit			= (void *)simple_exit,
 	.name			= "simple",

--- a/tools/sched_ext/scx_example_userland.bpf.c
+++ b/tools/sched_ext/scx_example_userland.bpf.c
@@ -122,7 +122,7 @@ s32 BPF_STRUCT_OPS(userland_select_cpu, struct task_struct *p,
 			return prev_cpu;
 		}
 
-		cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr);
+		cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
 		if (cpu >= 0) {
 			tctx->force_local = true;
 			return cpu;


### PR DESCRIPTION
Fixes for a couple tricky bugs and an improvement to select_cpu_dfl().

*  All schedulers w/ vtime scheduling wasn't updating p->dsq.vtime on scheduler reloads or, if applicable, cgroup migrations. This could get some unlucky tasks stuck way in the future stalling them severely. It's likely that we haven't noticed this with web benchmarks because web machines never completely peg themselves.
* ttwu_queue path skips select_cpu() which can confuse some of the SCX schedulers. Fixed by disabling ttwu_queue for tasks on SCX.
* It turned out that going for a different CPU whose SMT siblings are all idle is usually better than sticking with partially free @prev_cpu. select_cpu_dfl() is updated accordingly.

Atropos saw a lot of updates:

* Execution stall bug caused by queueing on and waking different domains fixed.
* Load balancer updated so that it reliably and gradually reaches equilibrium.
* Tuner which runs every 100ms and tells the BPF portion to adapt to the current per-domain utilization level has been added. This allows turning on/off certain greedy execution optimizations based on CPU saturation state.
* PUSH/KICK_GREEDY optimizations implemented. Observed to improve work conservation and thus bandwidth w/ kcryptd benchmark. Would likely make latencies more consistent too.
* Improve handling of possible but not online CPUs.
* Other cleanups and improvements.

With these improvements, on an AMD zen2 CPU, atropos reliably outperforms CFS when running fio randrw workloads on a dm-crypted SSD across different concurrency levels.