### PR TITLE
SCX: s/task_on_scx()/task_should_scx()/ and add new task_on_scx() whi…

### DIFF
--- a/kernel/sched/debug.c
+++ b/kernel/sched/debug.c
@@ -1097,7 +1097,7 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
 		P(dl.deadline);
 	}
 #ifdef CONFIG_SCHED_CLASS_EXT
-	__PS("ext.enabled", p->sched_class == &ext_sched_class);
+	__PS("ext.enabled", task_on_scx(p));
 #endif
 #undef PN_SCHEDSTAT
 #undef P_SCHEDSTAT

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -2867,7 +2867,7 @@ static void scx_cgroup_config_knobs(void) {}
  * Used by sched_fork() and __setscheduler_prio() to pick the matching
  * sched_class. dl/rt are already handled.
  */
-bool task_on_scx(struct task_struct *p)
+bool task_should_scx(struct task_struct *p)
 {
 	if (!scx_enabled() || scx_ops_disabling())
 		return false;

--- a/kernel/sched/ext.h
+++ b/kernel/sched/ext.h
@@ -110,7 +110,12 @@ DECLARE_STATIC_KEY_FALSE(__scx_switched_all);
 
 DECLARE_STATIC_KEY_FALSE(scx_ops_cpu_preempt);
 
-bool task_on_scx(struct task_struct *p);
+static inline bool task_on_scx(struct task_struct *p)
+{
+	return scx_enabled() && p->sched_class == &ext_sched_class;
+}
+
+bool task_should_scx(struct task_struct *p);
 void scx_pre_fork(struct task_struct *p);
 int scx_fork(struct task_struct *p);
 void scx_post_fork(struct task_struct *p);
@@ -198,6 +203,7 @@ bool scx_prio_less(const struct task_struct *a, const struct task_struct *b,
 #define scx_enabled()		false
 #define scx_switched_all()	false
 
+static inline bool task_on_scx(struct task_struct *p) { return false; }
 static inline void scx_pre_fork(struct task_struct *p) {}
 static inline int scx_fork(struct task_struct *p) { return 0; }
 static inline void scx_post_fork(struct task_struct *p) {}


### PR DESCRIPTION
…ch tests current state

Contrary to the name, task_on_scx() determined whether a task should be switched to SCX not whether it's currently on it. This is a bit confusing and makes it tricky to name a function which actually tests whether a task is currently on ext_sched_class.

* Rename task_on_scx() to task_should_scx().

* Add task_on_scx() which tests whether the specified task is currently on ext_sched_class and replace explicit tests in kernel/sched/core.c and debug.c.