### PR TITLE
SCX: Use "idle core" instead of "whole cpu"

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -1958,7 +1958,7 @@ retry:
 		if (cpu < nr_cpu_ids)
 			goto found;
 
-		if (flags & SCX_PICK_IDLE_CPU_WHOLE)
+		if (flags & SCX_PICK_IDLE_CORE)
 			return -EBUSY;
 	}
 
@@ -2009,7 +2009,7 @@ static s32 scx_select_cpu_dfl(struct task_struct *p, s32 prev_cpu, u64 wake_flag
 			return prev_cpu;
 		}
 
-		cpu = scx_pick_idle_cpu(p->cpus_ptr, SCX_PICK_IDLE_CPU_WHOLE);
+		cpu = scx_pick_idle_cpu(p->cpus_ptr, SCX_PICK_IDLE_CORE);
 		if (cpu >= 0) {
 			p->scx.flags |= SCX_TASK_ENQ_LOCAL;
 			return cpu;

--- a/kernel/sched/ext.h
+++ b/kernel/sched/ext.h
@@ -92,7 +92,7 @@ enum scx_kick_flags {
 };
 
 enum scx_pick_idle_cpu_flags {
-	SCX_PICK_IDLE_CPU_WHOLE	= 1LLU << 0,	/* pick a CPU whose SMT siblings are also idle */
+	SCX_PICK_IDLE_CORE	= 1LLU << 0,	/* pick a CPU whose SMT siblings are also idle */
 };
 
 #ifdef CONFIG_SCHED_CLASS_EXT


### PR DESCRIPTION
While "core" is a heavily overloaded word, it's what used inside the kernel to describe a whole physical SMT group. Let's use that in SCX and atropos too.