### PR TITLE
scx_atropos: Update various dependencies

### DIFF
--- a/tools/sched_ext/scx_atropos/Cargo.toml
+++ b/tools/sched_ext/scx_atropos/Cargo.toml
@@ -12,8 +12,8 @@ bitvec = { version = "1.0", features = ["serde"] }
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
 hex = "0.4.3"
-libbpf-rs = "0.19.1"
-libbpf-sys = { version = "1.0.4", features = ["novendor", "static"] }
+libbpf-rs = "0.21.0"
+libbpf-sys = { version = "1.2.0", features = ["novendor", "static"] }
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
@@ -21,7 +21,7 @@ simplelog = "0.12.0"
 
 [build-dependencies]
 bindgen = { version = "0.61.0" }
-libbpf-cargo = "0.13.0"
+libbpf-cargo = "0.21.0"
 
 [features]
 enable_backtrace = []

--- a/tools/sched_ext/scx_atropos/src/main.rs
+++ b/tools/sched_ext/scx_atropos/src/main.rs
@@ -25,6 +25,9 @@ use anyhow::Context;
 use anyhow::Result;
 use bitvec::prelude::*;
 use clap::Parser;
+use libbpf_rs::skel::OpenSkel as _;
+use libbpf_rs::skel::Skel as _;
+use libbpf_rs::skel::SkelBuilder as _;
 use log::info;
 use log::trace;
 use log::warn;
@@ -140,12 +143,9 @@ fn now_monotonic() -> u64 {
     time.tv_sec as u64 * 1_000_000_000 + time.tv_nsec as u64
 }
 
-fn clear_map(map: &mut libbpf_rs::Map) {
-    // XXX: libbpf_rs has some design flaw that make it impossible to
-    // delete while iterating despite it being safe so we alias it here
-    let deleter: &mut libbpf_rs::Map = unsafe { &mut *(map as *mut _) };
+fn clear_map(map: &libbpf_rs::Map) {
     for key in map.keys() {
-        let _ = deleter.delete(&key);
+        let _ = map.delete(&key);
     }
 }
 


### PR DESCRIPTION
Update libbpf-rs and libbpf-cargo to 0.21, which is the most recent version. Also update libbpf-sys to 1.2.0, which is a requirement for .struct_ops.link support that the program uses (and which got added with libbpf 1.2).