### PR TITLE
scx: Make task_on_scx() take const task_struct

### DIFF
--- a/kernel/sched/ext.h
+++ b/kernel/sched/ext.h
@@ -121,7 +121,7 @@ DECLARE_STATIC_KEY_FALSE(__scx_switched_all);
 
 DECLARE_STATIC_KEY_FALSE(scx_ops_cpu_preempt);
 
-static inline bool task_on_scx(struct task_struct *p)
+static inline bool task_on_scx(const struct task_struct *p)
 {
 	return scx_enabled() && p->sched_class == &ext_sched_class;
 }
@@ -214,7 +214,7 @@ bool scx_prio_less(const struct task_struct *a, const struct task_struct *b,
 #define scx_enabled()		false
 #define scx_switched_all()	false
 
-static inline bool task_on_scx(struct task_struct *p) { return false; }
+static inline bool task_on_scx(const struct task_struct *p) { return false; }
 static inline void scx_pre_fork(struct task_struct *p) {}
 static inline int scx_fork(struct task_struct *p) { return 0; }
 static inline void scx_post_fork(struct task_struct *p) {}


### PR DESCRIPTION
task_on_scx() takes a struct task_struct *p, but it's called by __task_prio() in CONFIG_SCHED_CORE which takes a const struct task_struct *. This can cause the build to fail due to incompatible pointer types:

kernel/sched/core.c:170:18: error: passing 'const struct task_struct *' to parameter of type 'struct task_struct *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
        if (task_on_scx(p))
                        ^
kernel/sched/ext.h:124:52: note: passing argument to parameter 'p' here static inline bool task_on_scx(struct task_struct *p)

Fix task_on_scx() so this doesn't happen.