### PR TITLE
scx: atropos: Use fb-procfs crate

### DIFF
--- a/tools/sched_ext/scx_atropos/Cargo.toml
+++ b/tools/sched_ext/scx_atropos/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.65"
 bitvec = { version = "1.0", features = ["serde"] }
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
+fb_procfs = "0.7.0"
 hex = "0.4.3"
 libbpf-rs = "0.21.0"
 libbpf-sys = { version = "1.2.0", features = ["novendor", "static"] }


### PR DESCRIPTION
fb-procfs crate supports hotplug CPUs now, so migrate back to that for measuring CPU util.