### PR TITLE
scx: Convert user space schedulers to use __{s,u}{32,64} types

### DIFF
--- a/tools/sched_ext/scx_central.c
+++ b/tools/sched_ext/scx_central.c
@@ -4,7 +4,6 @@
  * Copyright (c) 2022 Tejun Heo <tj@kernel.org>
  * Copyright (c) 2022 David Vernet <dvernet@meta.com>
  */
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <unistd.h>
 #include <signal.h>
@@ -36,8 +35,8 @@ int main(int argc, char **argv)
 {
 	struct scx_central *skel;
 	struct bpf_link *link;
-	u64 seq = 0;
-	s32 opt;
+	__u64 seq = 0;
+	__s32 opt;
 
 	signal(SIGINT, sigint_handler);
 	signal(SIGTERM, sigint_handler);
@@ -70,7 +69,7 @@ int main(int argc, char **argv)
 	assert(link);
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {
-		printf("[SEQ %lu]\n", seq++);
+		printf("[SEQ %llu]\n", seq++);
 		printf("total   :%10lu    local:%10lu   queued:%10lu  lost:%10lu\n",
 		       skel->bss->nr_total,
 		       skel->bss->nr_locals,

--- a/tools/sched_ext/scx_flatcg.c
+++ b/tools/sched_ext/scx_flatcg.c
@@ -4,10 +4,10 @@
  * Copyright (c) 2023 Tejun Heo <tj@kernel.org>
  * Copyright (c) 2023 David Vernet <dvernet@meta.com>
  */
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <signal.h>
 #include <unistd.h>
+#include <libgen.h>
 #include <limits.h>
 #include <fcntl.h>
 #include <time.h>
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
 	__u64 last_cpu_sum = 0, last_cpu_idle = 0;
 	__u64 last_stats[FCG_NR_STATS] = {};
 	unsigned long seq = 0;
-	s32 opt;
+	__s32 opt;
 
 	signal(SIGINT, sigint_handler);
 	signal(SIGTERM, sigint_handler);

--- a/tools/sched_ext/scx_pair.c
+++ b/tools/sched_ext/scx_pair.c
@@ -4,7 +4,6 @@
  * Copyright (c) 2022 Tejun Heo <tj@kernel.org>
  * Copyright (c) 2022 David Vernet <dvernet@meta.com>
  */
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <unistd.h>
 #include <signal.h>
@@ -38,8 +37,8 @@ int main(int argc, char **argv)
 {
 	struct scx_pair *skel;
 	struct bpf_link *link;
-	u64 seq = 0;
-	s32 stride, i, opt, outer_fd;
+	__u64 seq = 0;
+	__s32 stride, i, opt, outer_fd;
 
 	signal(SIGINT, sigint_handler);
 	signal(SIGTERM, sigint_handler);
@@ -113,13 +112,13 @@ int main(int argc, char **argv)
 
 	printf("Initializing");
         for (i = 0; i < MAX_CGRPS; i++) {
-		s32 inner_fd;
+		__s32 inner_fd;
 
 		if (exit_req)
 			break;
 
 		inner_fd = bpf_map_create(BPF_MAP_TYPE_QUEUE, NULL, 0,
-					  sizeof(u32), MAX_QUEUED, NULL);
+					  sizeof(__u32), MAX_QUEUED, NULL);
 		assert(inner_fd >= 0);
 		assert(!bpf_map_update_elem(outer_fd, &i, &inner_fd, BPF_ANY));
 		close(inner_fd);
@@ -137,7 +136,7 @@ int main(int argc, char **argv)
 	assert(link);
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {
-		printf("[SEQ %lu]\n", seq++);
+		printf("[SEQ %llu]\n", seq++);
 		printf(" total:%10lu dispatch:%10lu   missing:%10lu\n",
 		       skel->bss->nr_total,
 		       skel->bss->nr_dispatched,

--- a/tools/sched_ext/scx_qmap.c
+++ b/tools/sched_ext/scx_qmap.c
@@ -4,7 +4,6 @@
  * Copyright (c) 2022 Tejun Heo <tj@kernel.org>
  * Copyright (c) 2022 David Vernet <dvernet@meta.com>
  */
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/tools/sched_ext/scx_simple.c
+++ b/tools/sched_ext/scx_simple.c
@@ -4,7 +4,6 @@
  * Copyright (c) 2022 Tejun Heo <tj@kernel.org>
  * Copyright (c) 2022 David Vernet <dvernet@meta.com>
  */
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <unistd.h>
 #include <signal.h>
@@ -32,11 +31,11 @@ static void sigint_handler(int simple)
 	exit_req = 1;
 }
 
-static void read_stats(struct scx_simple *skel, u64 *stats)
+static void read_stats(struct scx_simple *skel, __u64 *stats)
 {
 	int nr_cpus = libbpf_num_possible_cpus();
-	u64 cnts[2][nr_cpus];
-	u32 idx;
+	__u64 cnts[2][nr_cpus];
+	__u32 idx;
 
 	memset(stats, 0, sizeof(stats[0]) * 2);
 
@@ -56,7 +55,7 @@ int main(int argc, char **argv)
 {
 	struct scx_simple *skel;
 	struct bpf_link *link;
-	u32 opt;
+	__u32 opt;
 
 	signal(SIGINT, sigint_handler);
 	signal(SIGTERM, sigint_handler);
@@ -86,10 +85,10 @@ int main(int argc, char **argv)
 	assert(link);
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {
-		u64 stats[2];
+		__u64 stats[2];
 
 		read_stats(skel, stats);
-		printf("local=%lu global=%lu\n", stats[0], stats[1]);
+		printf("local=%llu global=%llu\n", stats[0], stats[1]);
 		fflush(stdout);
 		sleep(1);
 	}

--- a/tools/sched_ext/scx_userland.c
+++ b/tools/sched_ext/scx_userland.c
@@ -15,7 +15,6 @@
  * Copyright (c) 2022 Tejun Heo <tj@kernel.org>
  * Copyright (c) 2022 David Vernet <dvernet@meta.com>
  */
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <unistd.h>
 #include <sched.h>
@@ -101,7 +100,7 @@ static __u32 task_pid(const struct enqueued_task *task)
 	return ((uintptr_t)task - (uintptr_t)tasks) / sizeof(*task);
 }
 
-static int dispatch_task(s32 pid)
+static int dispatch_task(__s32 pid)
 {
 	int err;
 


### PR DESCRIPTION
When trying to compile the schedulers from source in different contexts, it can be a pain to use the kernel types. Let's update the schedulers to use the types exported from UAPI headers, and get rid of the _GNU_SOURCE macro.