### PR TITLE
scx: Use explicit checks instead of asserts

### DIFF
--- a/tools/sched_ext/Makefile
+++ b/tools/sched_ext/Makefile
@@ -168,27 +168,28 @@ endif
 	$(Q)$(BPFTOOL) gen skeleton $(<:.o=.linked3.o) name $(<:.bpf.o=) > $@
 	$(Q)$(BPFTOOL) gen subskeleton $(<:.o=.linked3.o) name $(<:.bpf.o=) > $(@:.skel.h=.subskel.h)
 
-scx_simple: scx_simple.c scx_simple.skel.h user_exit_info.h
+scx_simple: scx_simple.c scx_simple.skel.h user_exit_info.h scx_user_common.h
 	$(CC) $(CFLAGS) -c $< -o $@.o
 	$(CC) -o $@ $@.o $(HOST_BPFOBJ) $(LDFLAGS)
 
-scx_qmap: scx_qmap.c scx_qmap.skel.h user_exit_info.h
+scx_qmap: scx_qmap.c scx_qmap.skel.h user_exit_info.h scx_user_common.h
 	$(CC) $(CFLAGS) -c $< -o $@.o
 	$(CC) -o $@ $@.o $(HOST_BPFOBJ) $(LDFLAGS)
 
-scx_central: scx_central.c scx_central.skel.h user_exit_info.h
+scx_central: scx_central.c scx_central.skel.h user_exit_info.h scx_user_common.h
 	$(CC) $(CFLAGS) -c $< -o $@.o
 	$(CC) -o $@ $@.o $(HOST_BPFOBJ) $(LDFLAGS)
 
-scx_pair: scx_pair.c scx_pair.skel.h user_exit_info.h
+scx_pair: scx_pair.c scx_pair.skel.h user_exit_info.h scx_user_common.h
 	$(CC) $(CFLAGS) -c $< -o $@.o
 	$(CC) -o $@ $@.o $(HOST_BPFOBJ) $(LDFLAGS)
 
-scx_flatcg: scx_flatcg.c scx_flatcg.skel.h user_exit_info.h
+scx_flatcg: scx_flatcg.c scx_flatcg.skel.h user_exit_info.h scx_user_common.h
 	$(CC) $(CFLAGS) -c $< -o $@.o
 	$(CC) -o $@ $@.o $(HOST_BPFOBJ) $(LDFLAGS)
 
-scx_userland: scx_userland.c scx_userland.skel.h scx_userland.h user_exit_info.h
+scx_userland: scx_userland.c scx_userland.skel.h scx_userland.h user_exit_info.h \
+	      scx_user_common.h
 	$(CC) $(CFLAGS) -c $< -o $@.o
 	$(CC) -o $@ $@.o $(HOST_BPFOBJ) $(LDFLAGS)
 

--- a/tools/sched_ext/scx_central.c
+++ b/tools/sched_ext/scx_central.c
@@ -7,11 +7,11 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <signal.h>
-#include <assert.h>
 #include <libgen.h>
 #include <bpf/bpf.h>
 #include "user_exit_info.h"
 #include "scx_central.skel.h"
+#include "scx_user_common.h"
 
 const char help_fmt[] =
 "A central FIFO sched_ext scheduler.\n"
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
 	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 
 	skel = scx_central__open();
-	assert(skel);
+	SCX_BUG_ON(!skel, "Failed to open skel");
 
 	skel->rodata->central_cpu = 0;
 	skel->rodata->nr_cpu_ids = libbpf_num_possible_cpus();
@@ -63,10 +63,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	assert(!scx_central__load(skel));
+	SCX_BUG_ON(scx_central__load(skel), "Failed to load skel");
 
 	link = bpf_map__attach_struct_ops(skel->maps.central_ops);
-	assert(link);
+	SCX_BUG_ON(!link, "Failed to attach struct_ops");
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {
 		printf("[SEQ %llu]\n", seq++);

--- a/tools/sched_ext/scx_qmap.c
+++ b/tools/sched_ext/scx_qmap.c
@@ -8,11 +8,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <signal.h>
-#include <assert.h>
 #include <libgen.h>
 #include <bpf/bpf.h>
 #include "user_exit_info.h"
 #include "scx_qmap.skel.h"
+#include "scx_user_common.h"
 
 const char help_fmt[] =
 "A simple five-level FIFO queue sched_ext scheduler.\n"
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 
 	skel = scx_qmap__open();
-	assert(skel);
+	SCX_BUG_ON(!skel, "Failed to open skel");
 
 	while ((opt = getopt(argc, argv, "s:e:t:T:l:d:ph")) != -1) {
 		switch (opt) {
@@ -82,10 +82,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	assert(!scx_qmap__load(skel));
+	SCX_BUG_ON(scx_qmap__load(skel), "Failed to load skel");
 
 	link = bpf_map__attach_struct_ops(skel->maps.qmap_ops);
-	assert(link);
+	SCX_BUG_ON(!link, "Failed to attach struct_ops");
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {
 		long nr_enqueued = skel->bss->nr_enqueued;

--- a/tools/sched_ext/scx_simple.c
+++ b/tools/sched_ext/scx_simple.c
@@ -7,11 +7,11 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <signal.h>
-#include <assert.h>
 #include <libgen.h>
 #include <bpf/bpf.h>
 #include "user_exit_info.h"
 #include "scx_simple.skel.h"
+#include "scx_user_common.h"
 
 const char help_fmt[] =
 "A simple sched_ext scheduler.\n"
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
 	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 
 	skel = scx_simple__open();
-	assert(skel);
+	SCX_BUG_ON(!skel, "Failed to open skel");
 
 	while ((opt = getopt(argc, argv, "fph")) != -1) {
 		switch (opt) {
@@ -79,10 +79,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	assert(!scx_simple__load(skel));
+	SCX_BUG_ON(scx_simple__load(skel), "Failed to load skel");
 
 	link = bpf_map__attach_struct_ops(skel->maps.simple_ops);
-	assert(link);
+	SCX_BUG_ON(!link, "Failed to attach struct_ops");
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {
 		__u64 stats[2];

--- a/tools/sched_ext/scx_user_common.h
+++ b/tools/sched_ext/scx_user_common.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2023 Tejun Heo <tj@kernel.org>
+ * Copyright (c) 2023 David Vernet <dvernet@meta.com>
+ */
+#ifndef __SCHED_EXT_USER_COMMON_H
+#define __SCHED_EXT_USER_COMMON_H
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __KERNEL__
+#error "Should not be included by BPF programs"
+#endif
+
+#define SCX_BUG(__fmt, ...)							\
+	do {									\
+		fprintf(stderr, "%s:%d [scx panic]: %s\n", __FILE__, __LINE__,	\
+			strerror(errno));					\
+		fprintf(stderr, __fmt __VA_OPT__(,) __VA_ARGS__);		\
+		fprintf(stderr, "\n");						\
+										\
+		exit(EXIT_FAILURE);						\
+	} while (0)
+
+#define SCX_BUG_ON(__cond, __fmt, ...)					\
+	do {								\
+		if (__cond)						\
+			SCX_BUG((__fmt) __VA_OPT__(,) __VA_ARGS__);	\
+	} while (0)
+
+#endif	/* __SCHED_EXT_USER_COMMON_H */


### PR DESCRIPTION
On some build systems, asserts are compiled out. We're currently using asserts on some actual operations, such as loading a prog. Let's update all of our progs to explicitly check return values where appropriate so we don't accidentally compile out real logic.