### PR TITLE
scx: Adjust a couple of small things in rusty.bpf.c

### DIFF
--- a/tools/sched_ext/scx_rusty/src/bpf/rusty.bpf.c
+++ b/tools/sched_ext/scx_rusty/src/bpf/rusty.bpf.c
@@ -273,7 +273,7 @@ static bool task_set_domain(struct task_ctx *task_ctx, struct task_struct *p,
 s32 BPF_STRUCT_OPS(rusty_select_cpu, struct task_struct *p, s32 prev_cpu,
 		   u64 wake_flags)
 {
-	struct cpumask *idle_smtmask = scx_bpf_get_idle_smtmask();
+	const struct cpumask *idle_smtmask = scx_bpf_get_idle_smtmask();
 	struct task_ctx *task_ctx;
 	struct bpf_cpumask *p_cpumask;
 	pid_t pid = p->pid;
@@ -933,7 +933,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init)
 			return ret;
 	}
 
-	for (u32 i = 0; i < nr_cpus; i++)
+	bpf_for(i, 0, nr_cpus)
 		pcpu_ctx[i].dom_rr_cur = i;
 
 	cpumask = bpf_cpumask_create();


### PR DESCRIPTION
rusty.bpf.c has a few small places where we can improve either the formatting of the code, or the logic. In rusty_select_cpu(), we declare the idle_smtmask as struct cpumask *, when it could be const. Also, when initializing the pcpu_ctx, we're using an actual for-loop instead of bpf_for. Let's just fix up these small issues.