### PR TITLE
scx: Make cpumask arg to ops.set_cpumask() const

### DIFF
--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -352,7 +352,8 @@ struct sched_ext_ops {
 	 *
 	 * Update @p's CPU affinity to @cpumask.
 	 */
-	void (*set_cpumask)(struct task_struct *p, struct cpumask *cpumask);
+	void (*set_cpumask)(struct task_struct *p,
+			    const struct cpumask *cpumask);
 
 	/**
 	 * update_idle - Update the idle state of a CPU


### PR DESCRIPTION
The struct cpumask * argument to the ops.set_cpumask() op isn't const. It doesn't really matter in terms of mutability in a BPF program, but let's make it const just because it really is.