### PR TITLE
Use unsigned longs for atomics

### DIFF
--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -651,7 +651,7 @@ struct sched_ext_entity {
 	s32			holding_cpu;
 	u32			kf_mask;	/* see scx_kf_mask above */
 	struct task_struct	*kf_tasks[2];	/* see SCX_CALL_OP_TASK() */
-	atomic64_t		ops_state;
+	atomic_long_t		ops_state;
 	unsigned long		runnable_at;
 #ifdef CONFIG_SCHED_CORE
 	u64			core_sched_at;	/* see scx_prio_less() */

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -94,7 +94,7 @@ struct static_key_false scx_has_op[SCX_NR_ONLINE_OPS] =
 static atomic_t scx_exit_type = ATOMIC_INIT(SCX_EXIT_DONE);
 static struct scx_exit_info scx_exit_info;
 
-static atomic64_t scx_nr_rejected = ATOMIC64_INIT(0);
+static atomic_long_t scx_nr_rejected = ATOMIC_LONG_INIT(0);
 
 /*
  * The maximum amount of time in jiffies that a task may be runnable without
@@ -2248,7 +2248,7 @@ static int scx_ops_prepare_task(struct task_struct *p, struct task_group *tg)
 		 */
 		if (p->policy == SCHED_EXT) {
 			p->policy = SCHED_NORMAL;
-			atomic64_inc(&scx_nr_rejected);
+			atomic_long_inc(&scx_nr_rejected);
 		}
 
 		task_rq_unlock(rq, p, &rf);
@@ -3200,7 +3200,7 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 	atomic_set(&scx_exit_type, SCX_EXIT_NONE);
 	scx_warned_zero_slice = false;
 
-	atomic64_set(&scx_nr_rejected, 0);
+	atomic_long_set(&scx_nr_rejected, 0);
 
 	/*
 	 * Keep CPUs stable during enable so that the BPF scheduler can track
@@ -3414,8 +3414,8 @@ static int scx_debug_show(struct seq_file *m, void *v)
 	seq_printf(m, "%-30s: %ld\n", "switched_all", scx_switched_all());
 	seq_printf(m, "%-30s: %s\n", "enable_state",
 		   scx_ops_enable_state_str[scx_ops_enable_state()]);
-	seq_printf(m, "%-30s: %llu\n", "nr_rejected",
-		   atomic64_read(&scx_nr_rejected));
+	seq_printf(m, "%-30s: %lu\n", "nr_rejected",
+		   atomic_long_read(&scx_nr_rejected));
 	mutex_unlock(&scx_ops_enable_mutex);
 	return 0;
 }

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -129,7 +129,7 @@ static struct {
 #endif	/* CONFIG_SMP */
 
 /* for %SCX_KICK_WAIT */
-static u64 __percpu *scx_kick_cpus_pnt_seqs;
+static unsigned long __percpu *scx_kick_cpus_pnt_seqs;
 
 /*
  * Direct dispatch marker.
@@ -3634,7 +3634,7 @@ static const struct sysrq_key_op sysrq_sched_ext_reset_op = {
 static void kick_cpus_irq_workfn(struct irq_work *irq_work)
 {
 	struct rq *this_rq = this_rq();
-	u64 *pseqs = this_cpu_ptr(scx_kick_cpus_pnt_seqs);
+	unsigned long *pseqs = this_cpu_ptr(scx_kick_cpus_pnt_seqs);
 	int this_cpu = cpu_of(this_rq);
 	int cpu;
 

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -698,7 +698,7 @@ enum scx_rq_flags {
 struct scx_rq {
 	struct scx_dispatch_q	local_dsq;
 	struct list_head	watchdog_list;
-	u64			ops_qseq;
+	unsigned long		ops_qseq;
 	u64			extra_enq_flags;	/* see move_task_to_local_dsq() */
 	u32			nr_running;
 	u32			flags;

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -706,7 +706,7 @@ struct scx_rq {
 	cpumask_var_t		cpus_to_kick;
 	cpumask_var_t		cpus_to_preempt;
 	cpumask_var_t		cpus_to_wait;
-	u64			pnt_seq;
+	unsigned long		pnt_seq;
 	struct irq_work		kick_cpus_irq_work;
 };
 #endif /* CONFIG_SCHED_CLASS_EXT */


### PR DESCRIPTION
Some 32bit archs can't do 64bit store_release/load_acquire. Switch to atomic_long_t and unsigned longs.