### PR TITLE
scx: bpf_scx_btf_struct_access() should return -EACCES for unknown accesses

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3485,7 +3485,7 @@ static int bpf_scx_btf_struct_access(struct bpf_verifier_log *log,
 			return SCALAR_VALUE;
 	}
 
-	return 0;
+	return -EACCES;
 }
 
 static const struct bpf_func_proto *


### PR DESCRIPTION
The function is currently returning 0 for unknown accesses which means allowing writes to anything. Fix the default return value.