### PR TITLE
central: Allow specifying the slice length in the central scheduler

### DIFF
--- a/tools/sched_ext/scx_central.bpf.c
+++ b/tools/sched_ext/scx_central.bpf.c
@@ -58,6 +58,7 @@ enum {
 const volatile bool switch_partial;
 const volatile s32 central_cpu;
 const volatile u32 nr_cpu_ids = 1;	/* !0 for veristat, set during init */
+const volatile u64 slice_ns = SCX_SLICE_DFL;
 
 u64 nr_total, nr_locals, nr_queued, nr_lost_pids;
 u64 nr_timers, nr_dispatches, nr_mismatches, nr_retries;
@@ -263,7 +264,7 @@ static int central_timerfn(void *map, int *key, struct bpf_timer *timer)
 		/* kick iff the current one exhausted its slice */
 		started_at = ARRAY_ELEM_PTR(cpu_started_at, cpu, nr_cpu_ids);
 		if (started_at && *started_at &&
-		    vtime_before(now, *started_at + SCX_SLICE_DFL))
+		    vtime_before(now, *started_at + slice_ns))
 			continue;
 
 		/* and there's something pending */

--- a/tools/sched_ext/scx_central.c
+++ b/tools/sched_ext/scx_central.c
@@ -18,8 +18,9 @@ const char help_fmt[] =
 "\n"
 "See the top-level comment in .bpf.c for more details.\n"
 "\n"
-"Usage: %s [-c CPU] [-p]\n"
+"Usage: %s [-s SLICE_US] [-c CPU] [-p]\n"
 "\n"
+"  -s SLICE_US   Override slice duration\n"
 "  -c CPU        Override the central CPU (default: 0)\n"
 "  -p            Switch only tasks on SCHED_EXT policy intead of all\n"
 "  -h            Display this help and exit\n";
@@ -49,8 +50,11 @@ int main(int argc, char **argv)
 	skel->rodata->central_cpu = 0;
 	skel->rodata->nr_cpu_ids = libbpf_num_possible_cpus();
 
-	while ((opt = getopt(argc, argv, "c:ph")) != -1) {
+	while ((opt = getopt(argc, argv, "s:c:ph")) != -1) {
 		switch (opt) {
+		case 's':
+			skel->rodata->slice_ns = strtoull(optarg, NULL, 0) * 1000;
+			break;
 		case 'c':
 			skel->rodata->central_cpu = strtoul(optarg, NULL, 0);
 			break;


### PR DESCRIPTION
Researchers at Inria-Paris are experimenting with the central scheduler, and want to try setting different slice lengths to see how they affect performance for VMs running the NAS benchmarks. Let's make this convenient by allowing it to be passed as a parameter from user space.