### PR TITLE
central: Pin timer callbacks to central CPU

### DIFF
--- a/tools/sched_ext/scx_central.bpf.c
+++ b/tools/sched_ext/scx_central.bpf.c
@@ -303,6 +303,9 @@ int BPF_STRUCT_OPS_SLEEPABLE(central_init)
 	if (!timer)
 		return -ESRCH;
 
+	if (bpf_get_smp_processor_id() != central_cpu)
+		return -EINVAL;
+
 	bpf_timer_init(timer, &central_timer, CLOCK_MONOTONIC);
 	bpf_timer_set_callback(timer, central_timerfn);
 	ret = bpf_timer_start(timer, TIMER_INTERVAL_NS, 0);


### PR DESCRIPTION
The scx_central scheduler specifies an infinite slice for all cores other than a "central" core where scheduling decisions are made. This scheduler currently suffers from the fact that the BPF timer may be invoked on a different core than the central scheduler, due to BPF timers not supporting being pinned to specific CPUs.

That capability was proposed upstream for BPF in [0]. If and when it lands, we would need to invoke bpf_timer_start() from the core that we want the timer pinned to, because the API does not support specifying a core to have the timer invoked from. To accommodate this, we can affinitize the loading thread to the central CPU before loading the scheduler, and then pin from there.

[0]: https://lore.kernel.org/bpf/20231002234708.331192-2-void@manifault.com/T/

Though the BPF timer pinning feature has not yet landed, we can still set the stage for leveraging it by adding the logic to affinitize the loading thread to the central CPU. While we won't yet have a guarantee that the timer will be pinned to the same core throughout the runtime of the scheduler, in practice, it seems that affinitizing in this manner does make it very likely regardless. In addition, the user space component of the central scheduler doesn't benefit from running on a tickless core, so keeping it affinitized to the central CPU avoids it from preempting a task on a tickless core that would otherwise benefit from less preemption.