### PR TITLE
Fix sched_ext crashes on v6.6

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -432,7 +432,11 @@ scx_task_iter_next_filtered(struct scx_task_iter *iter)
 	struct task_struct *p;
 
 	while ((p = scx_task_iter_next(iter))) {
-		if (!is_idle_task(p))
+		/*
+		 * is_idle_task() tests %PF_IDLE which may not be set for CPUs
+		 * which haven't yet been onlined. Test sched_class directly.
+		 */
+		if (p->sched_class != &idle_sched_class)
 			return p;
 	}
 	return NULL;


### PR DESCRIPTION
Fix breakage introduced by upstream change to how PF_IDLE is set. This fixes #69.