### PR TITLE
scx: Add missing ) to $(error) invocation in Makefile

### DIFF
--- a/tools/sched_ext/Makefile
+++ b/tools/sched_ext/Makefile
@@ -26,7 +26,7 @@ CLANG_TARGET_FLAGS              := $(CLANG_TARGET_FLAGS_$(ARCH))
 
 ifeq ($(CROSS_COMPILE),)
 ifeq ($(CLANG_TARGET_FLAGS),)
-$(error Specify CROSS_COMPILE or add '--target=' option to lib.mk
+$(error Specify CROSS_COMPILE or add '--target=' option to lib.mk)
 else
 CLANG_FLAGS     += --target=$(CLANG_TARGET_FLAGS)
 endif # CLANG_TARGET_FLAGS


### PR DESCRIPTION
We're missing a closing ) on a branch that we never take. Let's close it just for correctness.