### PR TITLE
sched_ext: Break dispatch_to_cpu loop when running out of buffer slots

### DIFF
--- a/tools/sched_ext/scx_central.bpf.c
+++ b/tools/sched_ext/scx_central.bpf.c
@@ -142,6 +142,12 @@ static bool dispatch_to_cpu(s32 cpu)
 	s32 pid;
 
 	bpf_repeat(BPF_MAX_LOOPS) {
+		/* We might run out of dispatch buffer slots if we get too many cases of
+		 * tasks bouncing to the fallback DSQ, break if that happens.
+		 */
+		if (!scx_bpf_dispatch_nr_slots())
+			break;
+
 		if (bpf_map_pop_elem(&central_q, &pid))
 			break;
 


### PR DESCRIPTION
For a case where many tasks being popped from the central queue cannot be dispatched to the local DSQ of the target CPU, we will keep bouncing them to the fallback DSQ and continue the dispatch_to_cpu loop until we find one which can be dispatch to the local DSQ of the target CPU.

In a contrived case, it might be so that all tasks pin themselves to CPUs != target CPU, and due to their affinity cannot be dispatched to that CPUs local DSQ. If all of them are filling up the central queue, then we will keep looping in the dispatch_to_cpu loop and eventually run out of slots for the dispatch buffer. The nr_mismatched counter will quickly rise and the sched_ext core will notice the error and unload the BPF scheduler.

To remedy this, ensure that we break the dispatch_to_cpu loop when we can no longer perform a dispatch operation. The outer loop in central_dispatch for the central CPU should ensure the loop breaks when we run out of these slots and schedule a self-IPI to the local core, and allow the sched-ext core to consume the dispatch buffer before restarting the dispatch loop again.

A basic way to reproduce this scenario is to do:
taskset -c 0 perf bench sched messaging

The error in the kernel will be:
sched_ext: BPF scheduler "central" errored, disabling
sched_ext: runtime error (dispatch buffer overflow)
    bpf_prog_6a473147db3cec67_dispatch_to_cpu+0xc2/0x19a
    bpf_prog_c9e51ba75372a829_central_dispatch+0x103/0x1a5