### PR TITLE
Fix and update semantics for ops.enable() and ops.disable()

### DIFF
--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -693,6 +693,7 @@ struct sched_ext_entity {
 #ifdef CONFIG_SCHED_CORE
 	u64			core_sched_at;	/* see scx_prio_less() */
 #endif
+	u64			ddsq_id;
 
 	/* BPF scheduler modifiable fields */
 
@@ -716,12 +717,6 @@ struct sched_ext_entity {
 	 * recommended.
 	 */
 	u64			dsq_vtime;
-
-	/*
-	 * Used to track when a task has requested a direct dispatch from the
-	 * ops.select_cpu() path.
-	 */
-	u64			ddsq_id;
 
 	/*
 	 * If set, reject future sched_setscheduler(2) calls updating the policy

--- a/init/init_task.c
+++ b/init/init_task.c
@@ -108,6 +108,7 @@ struct task_struct init_task
 	.scx		= {
 		.dsq_node.fifo	= LIST_HEAD_INIT(init_task.scx.dsq_node.fifo),
 		.watchdog_node	= LIST_HEAD_INIT(init_task.scx.watchdog_node),
+		.flags		= 0,
 		.sticky_cpu	= -1,
 		.holding_cpu	= -1,
 		.ops_state	= ATOMIC_INIT(0),

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -535,9 +535,9 @@ static bool ops_cpu_valid(s32 cpu)
  * @err: -errno value to sanitize
  *
  * Verify @err is a valid -errno. If not, trigger scx_ops_error() and return
- * -%EPROTO. This is necessary because returning a rogue -errno up the chain can
- * cause misbehaviors. For an example, a large negative return from
- * ops.prep_enable() triggers an oops when passed up the call chain because the
+ * -%EPROTO. This is necessary because returning a rogue -errno up the chain
+ * can cause misbehaviors. For an example, a large negative return from
+ * ops.init_task() triggers an oops when passed up the call chain because the
  * value fails IS_ERR() test after being encoded with ERR_PTR() and then is
  * handled as a pointer.
  */
@@ -2279,11 +2279,11 @@ static struct cgroup *tg_cgrp(struct task_group *tg)
 		return &cgrp_dfl_root.cgrp;
 }
 
-#define SCX_ENABLE_ARGS_INIT_CGROUP(tg)		.cgroup = tg_cgrp(tg),
+#define SCX_INIT_TASK_ARGS_CGROUP(tg)		.cgroup = tg_cgrp(tg),
 
 #else	/* CONFIG_EXT_GROUP_SCHED */
 
-#define SCX_ENABLE_ARGS_INIT_CGROUP(tg)
+#define SCX_INIT_TASK_ARGS_CGROUP(tg)
 
 #endif	/* CONFIG_EXT_GROUP_SCHED */
 
@@ -2326,20 +2326,20 @@ static void scx_set_task_state(struct task_struct *p, enum scx_task_state state)
 	}
 }
 
-static int scx_ops_prepare_task(struct task_struct *p, struct task_group *tg)
+static int scx_ops_init_task(struct task_struct *p, struct task_group *tg)
 {
 	int ret;
 
 	p->scx.disallow = false;
 
-	if (SCX_HAS_OP(prep_enable)) {
-		struct scx_enable_args args = {
-			SCX_ENABLE_ARGS_INIT_CGROUP(tg)
+	if (SCX_HAS_OP(init_task)) {
+		struct scx_init_task_args args = {
+			SCX_INIT_TASK_ARGS_CGROUP(tg)
 		};
 
-		ret = SCX_CALL_OP_RET(SCX_KF_SLEEPABLE, prep_enable, p, &args);
+		ret = SCX_CALL_OP_RET(SCX_KF_SLEEPABLE, init_task, p, &args);
 		if (unlikely(ret)) {
-			ret = ops_sanitize_err("prep_enable", ret);
+			ret = ops_sanitize_err("init_task", ret);
 			return ret;
 		}
 	}
@@ -2356,8 +2356,8 @@ static int scx_ops_prepare_task(struct task_struct *p, struct task_group *tg)
 		 * We're either in fork or load path and @p->policy will be
 		 * applied right after. Reverting @p->policy here and rejecting
 		 * %SCHED_EXT transitions from scx_check_setscheduler()
-		 * guarantees that if ops.prep_enable() sets @p->disallow, @p
-		 * can never be in SCX.
+		 * guarantees that if ops.init_task() sets @p->disallow, @p can
+		 * never be in SCX.
 		 */
 		if (p->policy == SCHED_EXT) {
 			p->policy = SCHED_NORMAL;
@@ -2387,13 +2387,8 @@ static void scx_ops_enable_task(struct task_struct *p)
 	 * doesn't see a stale value if they inspect the task struct.
 	 */
 	set_task_scx_weight(p);
-	if (SCX_HAS_OP(enable)) {
-		struct scx_enable_args args = {
-			SCX_ENABLE_ARGS_INIT_CGROUP(task_group(p))
-		};
-
-		SCX_CALL_OP_TASK(SCX_KF_REST, enable, p, &args);
-	}
+	if (SCX_HAS_OP(enable))
+		SCX_CALL_OP_TASK(SCX_KF_REST, enable, p);
 	scx_set_task_state(p, SCX_TASK_ENABLED);
 
 	if (SCX_HAS_OP(set_weight))
@@ -2412,18 +2407,16 @@ static void scx_ops_disable_task(struct task_struct *p)
 
 static void scx_ops_exit_task(struct task_struct *p)
 {
-	lockdep_assert_rq_held(task_rq(p));
+	struct scx_exit_task_args args = {
+		.cancelled = false,
+	};
 
+	lockdep_assert_rq_held(task_rq(p));
 	switch (scx_get_task_state(p)) {
 	case SCX_TASK_NONE:
 		return;
 	case SCX_TASK_INIT:
-		if (SCX_HAS_OP(cancel_enable)) {
-			struct scx_enable_args args = {
-				SCX_ENABLE_ARGS_INIT_CGROUP(task_group(p))
-			};
-			SCX_CALL_OP(SCX_KF_REST, cancel_enable, p, &args);
-		}
+		args.cancelled = true;
 		break;
 	case SCX_TASK_READY:
 		break;
@@ -2432,6 +2425,8 @@ static void scx_ops_exit_task(struct task_struct *p)
 		break;
 	}
 
+	if (SCX_HAS_OP(exit_task))
+		SCX_CALL_OP(SCX_KF_REST, exit_task, p, &args);
 	scx_set_task_state(p, SCX_TASK_NONE);
 }
 
@@ -2451,7 +2446,7 @@ int scx_fork(struct task_struct *p)
 	percpu_rwsem_assert_held(&scx_fork_rwsem);
 
 	if (scx_enabled())
-		return scx_ops_prepare_task(p, task_group(p));
+		return scx_ops_init_task(p, task_group(p));
 	else
 		return 0;
 }
@@ -3368,7 +3363,7 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 		/*
 		 * Exit early if ops.init() triggered scx_bpf_error(). Not
 		 * strictly necessary as we'll fail transitioning into ENABLING
-		 * later but that'd be after calling ops.prep_enable() on all
+		 * later but that'd be after calling ops.init_task() on all
 		 * tasks and with -EBUSY which isn't very intuitive. Let's exit
 		 * early with success so that the condition is notified through
 		 * ops.exit() like other scx_bpf_error() invocations.
@@ -3448,13 +3443,13 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 		get_task_struct(p);
 		spin_unlock_irq(&scx_tasks_lock);
 
-		ret = scx_ops_prepare_task(p, task_group(p));
+		ret = scx_ops_init_task(p, task_group(p));
 		if (ret) {
 			put_task_struct(p);
 			spin_lock_irq(&scx_tasks_lock);
 			scx_task_iter_exit(&sti);
 			spin_unlock_irq(&scx_tasks_lock);
-			pr_err("sched_ext: ops.prep_enable() failed (%d) for %s[%d] while loading\n",
+			pr_err("sched_ext: ops.init_task() failed (%d) for %s[%d] while loading\n",
 			       ret, p->comm, p->pid);
 			goto err_disable_unlock;
 		}
@@ -3689,7 +3684,7 @@ static int bpf_scx_check_member(const struct btf_type *t,
 	u32 moff = __btf_member_bit_offset(t, member) / 8;
 
 	switch (moff) {
-	case offsetof(struct sched_ext_ops, prep_enable):
+	case offsetof(struct sched_ext_ops, init_task):
 #ifdef CONFIG_EXT_GROUP_SCHED
 	case offsetof(struct sched_ext_ops, cgroup_init):
 	case offsetof(struct sched_ext_ops, cgroup_exit):
@@ -3735,7 +3730,7 @@ static int bpf_scx_update(void *kdata, void *old_kdata)
 	 * sched_ext does not support updating the actively-loaded BPF
 	 * scheduler, as registering a BPF scheduler can always fail if the
 	 * scheduler returns an error code for e.g. ops.init(),
-	 * ops.prep_enable(), etc. Similarly, we can always race with
+	 * ops.init_task(), etc. Similarly, we can always race with
 	 * unregistration happening elsewhere, such as with sysrq.
 	 */
 	return -EOPNOTSUPP;
@@ -3948,7 +3943,7 @@ static const struct btf_kfunc_id_set scx_kfunc_set_init = {
  * @node: NUMA node to allocate from
  *
  * Create a custom DSQ identified by @dsq_id. Can be called from ops.init(),
- * ops.prep_enable(), ops.cgroup_init() and ops.cgroup_prep_move().
+ * ops.init_task(), ops.cgroup_init() and ops.cgroup_prep_move().
  */
 s32 scx_bpf_create_dsq(u64 dsq_id, s32 node)
 {

--- a/tools/testing/selftests/scx/.gitignore
+++ b/tools/testing/selftests/scx/.gitignore
@@ -2,6 +2,7 @@ dsp_fallbackdsq_fail
 dsp_localdsq_fail
 enq_last_no_enq_fails
 enqueue_select_cpu_fails
+init_enable_count
 minimal
 select_cpu_dfl
 select_cpu_dfl_nodispatch

--- a/tools/testing/selftests/scx/Makefile
+++ b/tools/testing/selftests/scx/Makefile
@@ -96,8 +96,8 @@ BPF_CFLAGS = -g -D__TARGET_ARCH_$(SRCARCH)					\
 	     -O2 -mcpu=v3
 
 # sort removes libbpf duplicates when not cross-building
-MAKE_DIRS := $(sort $(OBJ_DIR)/libbpf $(HOST_BUILD_DIR)/libbpf			\
-	       $(HOST_BUILD_DIR)/bpftool $(HOST_BUILD_DIR)/resolve_btfids	\
+MAKE_DIRS := $(sort $(OBJ_DIR)/libbpf $(OBJ_DIR)/libbpf				\
+	       $(OBJ_DIR)/bpftool $(OBJ_DIR)/resolve_btfids			\
 	       $(INCLUDE_DIR) $(SCXOBJ_DIR))
 
 $(MAKE_DIRS):
@@ -112,14 +112,14 @@ $(BPFOBJ): $(wildcard $(BPFDIR)/*.[ch] $(BPFDIR)/Makefile)			\
 		    DESTDIR=$(OUTPUT_DIR) prefix= all install_headers
 
 $(DEFAULT_BPFTOOL): $(wildcard $(BPFTOOLDIR)/*.[ch] $(BPFTOOLDIR)/Makefile)	\
-		    $(LIBBPF_OUTPUT) | $(HOST_BUILD_DIR)/bpftool
+		    $(LIBBPF_OUTPUT) | $(OBJ_DIR)/bpftool
 	$(Q)$(MAKE) $(submake_extras)  -C $(BPFTOOLDIR)				\
 		    ARCH= CROSS_COMPILE= CC=$(HOSTCC) LD=$(HOSTLD)		\
 		    EXTRA_CFLAGS='-g -O0'					\
-		    OUTPUT=$(HOST_BUILD_DIR)/bpftool/				\
-		    LIBBPF_OUTPUT=$(HOST_BUILD_DIR)/libbpf/			\
-		    LIBBPF_DESTDIR=$(HOST_OUTPUT_DIR)/				\
-		    prefix= DESTDIR=$(HOST_OUTPUT_DIR)/ install-bin
+		    OUTPUT=$(OBJ_DIR)/bpftool/					\
+		    LIBBPF_OUTPUT=$(OBJ_DIR)/libbpf/				\
+		    LIBBPF_DESTDIR=$(OUTPUT_DIR)/				\
+		    prefix= DESTDIR=$(OUTPUT_DIR)/ install-bin
 
 $(INCLUDE_DIR)/vmlinux.h: $(VMLINUX_BTF) $(BPFTOOL) | $(INCLUDE_DIR)
 ifeq ($(VMLINUX_H),)
@@ -148,16 +148,17 @@ $(INCLUDE_DIR)/%.bpf.skel.h: $(SCXOBJ_DIR)/%.bpf.o $(INCLUDE_DIR)/vmlinux.h $(BP
 # C schedulers #
 ################
 c-sched-targets :=			\
+	dsp_fallbackdsq_fail		\
+	dsp_localdsq_fail		\
+	enq_last_no_enq_fails		\
+	enqueue_select_cpu_fails	\
+	init_enable_count		\
 	minimal				\
 	select_cpu_dfl			\
 	select_cpu_dfl_nodispatch	\
 	select_cpu_dispatch		\
-	select_cpu_dispatch_dbl_dsp	\
 	select_cpu_dispatch_bad_dsq	\
-	enqueue_select_cpu_fails	\
-	enq_last_no_enq_fails		\
-	dsp_localdsq_fail		\
-	dsp_fallbackdsq_fail
+	select_cpu_dispatch_dbl_dsp
 
 $(c-sched-targets): %: $(filter-out %.bpf.c,%.c) $(INCLUDE_DIR)/%.bpf.skel.h
 	$(eval sched=$(notdir $@))
@@ -167,7 +168,7 @@ $(c-sched-targets): %: $(filter-out %.bpf.c,%.c) $(INCLUDE_DIR)/%.bpf.skel.h
 TEST_GEN_PROGS := $(c-sched-targets)
 
 override define CLEAN
-	rm -rf $(OUTPUT_DIR) $(HOST_OUTPUT_DIR)
+	rm -rf $(OUTPUT_DIR)
 	rm -f *.o *.bpf.o *.bpf.skel.h *.bpf.subskel.h
 	rm -f $(TEST_GEN_PROGS)
 endef

--- a/tools/testing/selftests/scx/dsp_localdsq_fail.bpf.c
+++ b/tools/testing/selftests/scx/dsp_localdsq_fail.bpf.c
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2024 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2024 David Vernet <dvernet@meta.com>
+ * Copyright (c) 2024 Tejun Heo <tj@kernel.org>
+ */
+#include <scx/common.bpf.h>
+
+char _license[] SEC("license") = "GPL";
+
+s32 BPF_STRUCT_OPS(dsp_localdsq_fail_select_cpu, struct task_struct *p,
+		   s32 prev_cpu, u64 wake_flags)
+{
+	s32 cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+
+	if (cpu >= 0) {
+		/* Shouldn't be allowed to vtime dispatch to a builtin DSQ. */
+		scx_bpf_dispatch_vtime(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL,
+				       p->scx.dsq_vtime, 0);
+		return cpu;
+	}
+
+	return prev_cpu;
+}
+
+s32 BPF_STRUCT_OPS(dsp_localdsq_fail_init)
+{
+	scx_bpf_switch_all();
+
+	return 0;
+}
+
+SEC(".struct_ops.link")
+struct sched_ext_ops dsp_localdsq_fail_ops = {
+	.select_cpu		= dsp_localdsq_fail_select_cpu,
+	.init			= dsp_localdsq_fail_init,
+	.name			= "dsp_localdsq_fail",
+	.timeout_ms		= 1000U,
+};

--- a/tools/testing/selftests/scx/dsp_localdsq_fail.c
+++ b/tools/testing/selftests/scx/dsp_localdsq_fail.c
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2024 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2024 David Vernet <dvernet@meta.com>
+ * Copyright (c) 2024 Tejun Heo <tj@kernel.org>
+ */
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <libgen.h>
+#include <bpf/bpf.h>
+#include <scx/common.h>
+#include <sys/wait.h>
+#include "dsp_localdsq_fail.bpf.skel.h"
+#include "scx_test.h"
+
+int main(int argc, char **argv)
+{
+	struct dsp_localdsq_fail *skel;
+	struct bpf_link *link;
+
+	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
+	skel = dsp_localdsq_fail__open_and_load();
+	SCX_BUG_ON(!skel, "Failed to open and load skel");
+
+	link = bpf_map__attach_struct_ops(skel->maps.dsp_localdsq_fail_ops);
+	SCX_BUG_ON(!link, "Failed to attach struct_ops");
+
+	sleep(1);
+
+	bpf_link__destroy(link);
+	dsp_localdsq_fail__destroy(skel);
+
+	return 0;
+}

--- a/tools/testing/selftests/scx/init_enable_count.bpf.c
+++ b/tools/testing/selftests/scx/init_enable_count.bpf.c
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * A scheduler that verifies that we do proper counting of init, enable, etc
+ * callbacks.
+ *
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2023 David Vernet <dvernet@meta.com>
+ * Copyright (c) 2023 Tejun Heo <tj@kernel.org>
+ */
+
+#include <scx/common.bpf.h>
+
+char _license[] SEC("license") = "GPL";
+
+u64 init_task_cnt, exit_task_cnt, enable_cnt, disable_cnt;
+volatile const bool switch_all;
+
+s32 BPF_STRUCT_OPS_SLEEPABLE(cnt_init_task, struct task_struct *p,
+			     struct scx_init_task_args *args)
+{
+	__sync_fetch_and_add(&init_task_cnt, 1);
+
+	return 0;
+}
+
+void BPF_STRUCT_OPS(cnt_exit_task, struct task_struct *p)
+{
+	__sync_fetch_and_add(&exit_task_cnt, 1);
+}
+
+void BPF_STRUCT_OPS(cnt_enable, struct task_struct *p)
+{
+	__sync_fetch_and_add(&enable_cnt, 1);
+}
+
+void BPF_STRUCT_OPS(cnt_disable, struct task_struct *p)
+{
+	__sync_fetch_and_add(&disable_cnt, 1);
+}
+
+s32 BPF_STRUCT_OPS(cnt_init)
+{
+	if (switch_all)
+		scx_bpf_switch_all();
+
+	return 0;
+}
+
+SEC(".struct_ops.link")
+struct sched_ext_ops init_enable_count_ops = {
+	.init_task	= cnt_init_task,
+	.exit_task	= cnt_exit_task,
+	.enable		= cnt_enable,
+	.disable	= cnt_disable,
+	.init		= cnt_init,
+	.name		= "init_enable_count",
+};

--- a/tools/testing/selftests/scx/init_enable_count.c
+++ b/tools/testing/selftests/scx/init_enable_count.c
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2023 David Vernet <dvernet@meta.com>
+ * Copyright (c) 2023 Tejun Heo <tj@kernel.org>
+ */
+#include <stdio.h>
+#include <unistd.h>
+#include <sched.h>
+#include <bpf/bpf.h>
+#include <scx/common.h>
+#include <sys/wait.h>
+#include "scx_test.h"
+#include "init_enable_count.bpf.skel.h"
+
+#define SCHED_EXT 7
+
+static struct init_enable_count *
+open_load_prog(bool global)
+{
+	struct init_enable_count *skel;
+
+	skel = init_enable_count__open();
+	SCX_BUG_ON(!skel, "Failed to open skel");
+
+	if (global)
+		skel->rodata->switch_all = global;
+
+	SCX_BUG_ON(init_enable_count__load(skel), "Failed to load skel");
+
+	return skel;
+}
+
+static void run_test(bool global)
+{
+	struct init_enable_count *skel;
+	struct bpf_link *link;
+	const u32 num_children = 5;
+	int ret, i, status;
+	struct sched_param param = {};
+	pid_t pids[num_children];
+
+	skel = open_load_prog(global);
+	link = bpf_map__attach_struct_ops(skel->maps.init_enable_count_ops);
+	SCX_BUG_ON(!link, "Failed to attach struct_ops");
+
+	/* SCHED_EXT children */
+	for (i = 0; i < num_children; i++) {
+		pids[i] = fork();
+		SCX_BUG_ON(pids[i] < 0, "Failed to fork child");
+
+		if (pids[i] == 0) {
+			ret = sched_setscheduler(0, SCHED_EXT, &param);
+			SCX_BUG_ON(ret, "Failed to set sched to sched_ext");
+
+			/*
+			 * Reset to SCHED_OTHER for half of them. Counts for
+			 * everything should still be the same regardless, as
+			 * ops.disable() is invoked even if a task is still on
+			 * SCHED_EXT before it exits.
+			 */
+			if (i % 2 == 0) {
+				ret = sched_setscheduler(0, SCHED_OTHER, &param);
+				SCX_BUG_ON(ret, "Failed to reset sched to normal");
+			}
+			exit(0);
+		}
+	}
+	for (i = 0; i < num_children; i++) {
+		SCX_BUG_ON(waitpid(pids[i], &status, 0) != pids[i],
+			   "Failed to wait for SCX child");
+		SCX_BUG_ON(status != 0, "SCX child %d exited with status %d",
+			   i, status);
+	}
+
+	/* SCHED_OTHER children */
+	for (i = 0; i < num_children; i++) {
+		pids[i] = fork();
+		if (pids[i] == 0)
+			exit(0);
+	}
+	for (i = 0; i < num_children; i++) {
+		SCX_BUG_ON(waitpid(pids[i], &status, 0) != pids[i],
+			   "Failed to wait for normal child");
+		SCX_BUG_ON(status != 0,
+			   "Normal child %d exited with status %d", i, status);
+	}
+
+	sleep(1);
+
+	SCX_GE(skel->bss->init_task_cnt, 2 * num_children);
+	SCX_GE(skel->bss->exit_task_cnt, 2 * num_children);
+
+	if (global) {
+		SCX_GE(skel->bss->enable_cnt, 2 * num_children);
+		SCX_GE(skel->bss->disable_cnt, 2 * num_children);
+	} else {
+		SCX_EQ(skel->bss->enable_cnt, num_children);
+		SCX_EQ(skel->bss->disable_cnt, num_children);
+	}
+
+	bpf_link__destroy(link);
+	init_enable_count__destroy(skel);
+}
+
+int main(int argc, char **argv)
+{
+	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
+	run_test(true);
+	run_test(false);
+
+	return 0;
+}

--- a/tools/testing/selftests/scx/select_cpu_dfl_nodispatch.bpf.c
+++ b/tools/testing/selftests/scx/select_cpu_dfl_nodispatch.bpf.c
@@ -70,8 +70,8 @@ void BPF_STRUCT_OPS(select_cpu_dfl_nodispatch_enqueue, struct task_struct *p,
 	scx_bpf_dispatch(p, dsq_id, SCX_SLICE_DFL, enq_flags);
 }
 
-s32 BPF_STRUCT_OPS(select_cpu_dfl_nodispatch_prep_enable,
-		   struct task_struct *p, struct scx_enable_args *args)
+s32 BPF_STRUCT_OPS(select_cpu_dfl_nodispatch_init_task,
+		   struct task_struct *p, struct scx_init_task_args *args)
 {
 	if (bpf_task_storage_get(&task_ctx_stor, p, 0,
 				 BPF_LOCAL_STORAGE_GET_F_CREATE))
@@ -91,7 +91,7 @@ SEC(".struct_ops.link")
 struct sched_ext_ops select_cpu_dfl_nodispatch_ops = {
 	.select_cpu		= select_cpu_dfl_nodispatch_select_cpu,
 	.enqueue		= select_cpu_dfl_nodispatch_enqueue,
-	.prep_enable		= select_cpu_dfl_nodispatch_prep_enable,
+	.init_task		= select_cpu_dfl_nodispatch_init_task,
 	.init			= select_cpu_dfl_nodispatch_init,
 	.name			= "select_cpu_dfl_nodispatch",
 };


### PR DESCRIPTION
- A task's scx.weight is properly set before ops.enable() on the fork path, but not on the BPF prog load path. Set it properly for both.
- ops.enable() (and a corresponding ops.disable()) is called once for every task on the system on the BPF prog load path, or the fork path. It would be useful to instead call ops.enable() whenever a task is about to run on scx, and ops.disable() whenever a task is no longer running on scx.