### PR TITLE
sched_ext: automatically disable scheduler on PM suspend

### DIFF
--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -61,6 +61,7 @@ enum scx_exit_kind {
 
 	SCX_EXIT_UNREG = 64,	/* BPF unregistration */
 	SCX_EXIT_SYSRQ,		/* requested by 'S' sysrq */
+	SCX_EXIT_PM,		/* exit on PM events (e.g., suspend) */
 
 	SCX_EXIT_ERROR = 1024,	/* runtime error, error msg contains details */
 	SCX_EXIT_ERROR_BPF,	/* ERROR but triggered through scx_bpf_error() */
@@ -113,6 +114,18 @@ enum scx_ops_flags {
 	SCX_OPS_ENQ_EXITING	= 1LLU << 2,
 
 	/*
+	 * Some schedulers may rely on external user-space components. In
+	 * presence of a power-management event, such as suspend or hibernate,
+	 * the user-space components can be frozen, potentially preventing any
+	 * further progress of the scheduler.
+	 *
+	 * To address this issue, introduce the @SCX_OPS_PM_AUTO_EXIT flag,
+	 * which can be set to automatically disable the scheduler when any
+	 * power-management event occurs.
+	 */
+	SCX_OPS_PM_AUTO_EXIT	= 1LLU << 3,
+
+	/*
 	 * CPU cgroup knob enable flags
 	 */
 	SCX_OPS_CGROUP_KNOB_WEIGHT = 1LLU << 16,	/* cpu.weight */
@@ -120,6 +133,7 @@ enum scx_ops_flags {
 	SCX_OPS_ALL_FLAGS	= SCX_OPS_KEEP_BUILTIN_IDLE |
 				  SCX_OPS_ENQ_LAST |
 				  SCX_OPS_ENQ_EXITING |
+				  SCX_OPS_PM_AUTO_EXIT |
 				  SCX_OPS_CGROUP_KNOB_WEIGHT,
 };
 


### PR DESCRIPTION
When the system enters a PM suspend state, such as suspend to memory or hibernate, the sched-ext watchdog fails to perform its periodic check.

This leads to the active scheduler being disabled, reporting an oops like the following, that could be misinterpreted as an actual stall:

 sched_ext: BPF scheduler "userland" errored, disabling
 sched_ext: runnable task stall (watchdog failed to check in for 3.565s)
    scheduler_tick+0x1d7/0x3f0
    update_process_times+0x89/0xb0
    tick_sched_handle+0x28/0x70
    tick_nohz_highres_handler+0x78/0xa0
    __hrtimer_run_queues+0x10f/0x2a0
    hrtimer_interrupt+0xf6/0x250
    __sysvec_apic_timer_interrupt+0x4e/0x150
    sysvec_apic_timer_interrupt+0x8d/0xd0
    asm_sysvec_apic_timer_interrupt+0x1b/0x20
    cpuidle_enter_state+0xda/0x730
    cpuidle_enter+0x2e/0x50
    call_cpuidle+0x23/0x60
    cpuidle_idle_call+0x11d/0x190
    do_idle+0x87/0xf0
    cpu_startup_entry+0x2a/0x30
    start_secondary+0x129/0x160
    secondary_startup_64_no_verify+0x17d/0x18b

While deactivating the sched-ext scheduler on a suspend/resume cycle is a reasonable approach for now, a more elegant solution would be to report an explicit message indicating that the scheduler has been disabled due to a PM suspend event.

With this change applied, the message reported in the kernel log looks like this:

 sched_ext: "userland" disabled on PM suspend

Subsequently, the scheduler can be easily reactivated on resume, if necessary, through user-space actions, for example using a pm-utils script.

This can help to identify potential "false posivitive" stalls in systems where PM events are more frequent, such as laptops or mobile/embedded devices.