### PR TITLE
Implement generic bypass mode and use it while PM operations are in progress

### DIFF
--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -616,7 +616,7 @@ enum scx_ent_flags {
 	SCX_TASK_STATE_0	= 1 << 3, /* first bit encoding the task's current state */
 	SCX_TASK_STATE_1	= 1 << 4, /* second bit encoding the task's current state */
 
-	SCX_TASK_WATCHDOG_RESET = 1 << 16, /* task watchdog counter should be reset */
+	SCX_TASK_RESET_RUNNABLE_AT = 1 << 16, /* runnable_at should be reset */
 	SCX_TASK_DEQD_FOR_SLEEP	= 1 << 17, /* last dequeue was for SLEEP */
 
 	SCX_TASK_CURSOR		= 1 << 31, /* iteration cursor, not a task */
@@ -680,7 +680,6 @@ struct sched_ext_entity {
 		struct list_head	fifo;	/* dispatch order */
 		struct rb_node		priq;	/* p->scx.dsq_vtime order */
 	} dsq_node;
-	struct list_head	watchdog_node;
 	u32			flags;		/* protected by rq lock */
 	u32			dsq_flags;	/* protected by dsq lock */
 	u32			weight;
@@ -689,7 +688,10 @@ struct sched_ext_entity {
 	u32			kf_mask;	/* see scx_kf_mask above */
 	struct task_struct	*kf_tasks[2];	/* see SCX_CALL_OP_TASK() */
 	atomic_long_t		ops_state;
+
+	struct list_head	runnable_node;	/* rq->scx.runnable_list */
 	unsigned long		runnable_at;
+
 #ifdef CONFIG_SCHED_CORE
 	u64			core_sched_at;	/* see scx_prio_less() */
 #endif

--- a/init/init_task.c
+++ b/init/init_task.c
@@ -107,7 +107,7 @@ struct task_struct init_task
 #ifdef CONFIG_SCHED_CLASS_EXT
 	.scx		= {
 		.dsq_node.fifo	= LIST_HEAD_INIT(init_task.scx.dsq_node.fifo),
-		.watchdog_node	= LIST_HEAD_INIT(init_task.scx.watchdog_node),
+		.runnable_node	= LIST_HEAD_INIT(init_task.scx.runnable_node),
 		.flags		= 0,
 		.sticky_cpu	= -1,
 		.holding_cpu	= -1,

--- a/kernel/sched/build_policy.c
+++ b/kernel/sched/build_policy.c
@@ -22,6 +22,7 @@
 #include <linux/cpuidle.h>
 #include <linux/jiffies.h>
 #include <linux/livepatch.h>
+#include <linux/pm.h>
 #include <linux/psi.h>
 #include <linux/seqlock_api.h>
 #include <linux/slab.h>

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -4555,7 +4555,7 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
 	p->scx.dsq		= NULL;
 	INIT_LIST_HEAD(&p->scx.dsq_node.fifo);
 	RB_CLEAR_NODE(&p->scx.dsq_node.priq);
-	INIT_LIST_HEAD(&p->scx.watchdog_node);
+	INIT_LIST_HEAD(&p->scx.runnable_node);
 	p->scx.flags		= 0;
 	p->scx.weight		= 0;
 	p->scx.sticky_cpu	= -1;

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -91,6 +91,7 @@ static DEFINE_MUTEX(scx_ops_enable_mutex);
 DEFINE_STATIC_KEY_FALSE(__scx_ops_enabled);
 DEFINE_STATIC_PERCPU_RWSEM(scx_fork_rwsem);
 static atomic_t scx_ops_enable_state_var = ATOMIC_INIT(SCX_OPS_DISABLED);
+static atomic_t scx_ops_bypass_depth = ATOMIC_INIT(0);
 static bool scx_switch_all_req;
 static bool scx_switching_all;
 DEFINE_STATIC_KEY_FALSE(__scx_switched_all);
@@ -497,7 +498,7 @@ static bool scx_ops_tryset_enable_state(enum scx_ops_enable_state to,
 
 static bool scx_ops_bypassing(void)
 {
-	return unlikely(scx_ops_enable_state() == SCX_OPS_DISABLING);
+	return unlikely(atomic_read(&scx_ops_bypass_depth));
 }
 
 /**
@@ -3017,7 +3018,8 @@ static void scx_cgroup_config_knobs(void) {}
  */
 bool task_should_scx(struct task_struct *p)
 {
-	if (!scx_enabled() || scx_ops_bypassing())
+	if (!scx_enabled() ||
+	    unlikely(scx_ops_enable_state() == SCX_OPS_DISABLING))
 		return false;
 	if (READ_ONCE(scx_switching_all))
 		return true;
@@ -3035,9 +3037,9 @@ static void scx_ops_fallback_enqueue(struct task_struct *p, u64 enq_flags)
 static void scx_ops_fallback_dispatch(s32 cpu, struct task_struct *prev) {}
 
 /**
- * scx_ops_bypass - Bypass scx_ops and guarantee forward progress
+ * scx_ops_bypass - [Un]bypass scx_ops and guarantee forward progress
  *
- * We must guarantee that all runnable tasks make forward progress without
+ * Bypassing guarantees that all runnable tasks make forward progress without
  * trusting the BPF scheduler. We can't grab any mutexes or rwsems as they might
  * be held by tasks that the BPF scheduler is forgetting to run, which
  * unfortunately also excludes toggling the static branches.
@@ -3057,14 +3059,26 @@ static void scx_ops_fallback_dispatch(s32 cpu, struct task_struct *prev) {}
  *
  * d. scx_prio_less() reverts to the default core_sched_at order.
  */
-static void scx_ops_bypass(void)
+static void scx_ops_bypass(bool bypass)
 {
 	struct scx_task_iter sti;
 	struct task_struct *p;
-	int cpu;
+	int depth, cpu;
 
-	scx_ops.enqueue = scx_ops_fallback_enqueue;
-	scx_ops.dispatch = scx_ops_fallback_dispatch;
+	if (bypass) {
+		depth = atomic_inc_return(&scx_ops_bypass_depth);
+		WARN_ON_ONCE(depth <= 0);
+		if (depth != 1)
+			return;
+
+		scx_ops.enqueue = scx_ops_fallback_enqueue;
+		scx_ops.dispatch = scx_ops_fallback_dispatch;
+	} else {
+		depth = atomic_dec_return(&scx_ops_bypass_depth);
+		WARN_ON_ONCE(depth < 0);
+		if (depth != 0)
+			return;
+	}
 
 	spin_lock_irq(&scx_tasks_lock);
 	scx_task_iter_init(&sti);
@@ -3133,22 +3147,20 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 	ei->kind = kind;
 	strlcpy(ei->reason, reason, sizeof(ei->reason));
 
+	/* guarantee forward progress by bypassing scx_ops */
+	scx_ops_bypass(true);
+
 	switch (scx_ops_set_enable_state(SCX_OPS_DISABLING)) {
+	case SCX_OPS_DISABLING:
+		WARN_ONCE(true, "sched_ext: duplicate disabling instance?");
+		break;
 	case SCX_OPS_DISABLED:
 		pr_warn("sched_ext: ops error detected without ops (%s)\n",
 			scx_exit_info.msg);
 		WARN_ON_ONCE(scx_ops_set_enable_state(SCX_OPS_DISABLED) !=
 			     SCX_OPS_DISABLING);
-		return;
-	case SCX_OPS_PREPPING:
-		break;
-	case SCX_OPS_DISABLING:
-		/* shouldn't happen but handle it like ENABLING if it does */
-		WARN_ONCE(true, "sched_ext: duplicate disabling instance?");
-		fallthrough;
-	case SCX_OPS_ENABLING:
-	case SCX_OPS_ENABLED:
-		scx_ops_bypass();
+		goto done;
+	default:
 		break;
 	}
 
@@ -3245,6 +3257,8 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 		     SCX_OPS_DISABLING);
 
 	scx_cgroup_config_knobs();
+done:
+	scx_ops_bypass(false);
 }
 
 static DEFINE_KTHREAD_WORK(scx_ops_disable_work, scx_ops_disable_workfn);

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -889,6 +889,13 @@ static void do_enqueue_task(struct rq *rq, struct task_struct *p, u64 enq_flags,
 	if (unlikely(!test_rq_online(rq)))
 		goto local;
 
+	if (scx_ops_bypassing()) {
+		if (enq_flags & SCX_ENQ_LAST)
+			goto local;
+		else
+			goto global;
+	}
+
 	/* see %SCX_OPS_ENQ_EXITING */
 	if (!static_branch_unlikely(&scx_ops_enq_exiting) &&
 	    unlikely(p->flags & PF_EXITING))
@@ -1609,7 +1616,7 @@ static int balance_one(struct rq *rq, struct task_struct *prev,
 	if (consume_dispatch_q(rq, rf, &scx_dsq_global))
 		return 1;
 
-	if (!SCX_HAS_OP(dispatch))
+	if (!SCX_HAS_OP(dispatch) || scx_ops_bypassing())
 		return 0;
 
 	dspc->rq = rq;
@@ -3026,16 +3033,6 @@ bool task_should_scx(struct task_struct *p)
 	return p->policy == SCHED_EXT;
 }
 
-static void scx_ops_fallback_enqueue(struct task_struct *p, u64 enq_flags)
-{
-	if (enq_flags & SCX_ENQ_LAST)
-		scx_bpf_dispatch(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL, enq_flags);
-	else
-		scx_bpf_dispatch(p, SCX_DSQ_GLOBAL, SCX_SLICE_DFL, enq_flags);
-}
-
-static void scx_ops_fallback_dispatch(s32 cpu, struct task_struct *prev) {}
-
 /**
  * scx_ops_bypass - [Un]bypass scx_ops and guarantee forward progress
  *
@@ -3048,16 +3045,17 @@ static void scx_ops_fallback_dispatch(s32 cpu, struct task_struct *prev) {}
  * the DISABLING state and then cycling the tasks through dequeue/enqueue to
  * force global FIFO scheduling.
  *
- * a. ops.enqueue() and .dispatch() are overridden for simple global FIFO
- *    scheduling.
+ * a. ops.enqueue() is ignored and tasks are queued in simple global FIFO order.
  *
- * b. balance_scx() never sets %SCX_TASK_BAL_KEEP as the slice value can't be
+ * b. ops.dispatch() is ignored.
+ *
+ * c. balance_scx() never sets %SCX_TASK_BAL_KEEP as the slice value can't be
  *    trusted. Whenever a tick triggers, the running task is rotated to the tail
  *    of the queue with core_sched_at touched.
  *
- * c. pick_next_task() suppresses zero slice warning.
+ * d. pick_next_task() suppresses zero slice warning.
  *
- * d. scx_prio_less() reverts to the default core_sched_at order.
+ * e. scx_prio_less() reverts to the default core_sched_at order.
  */
 static void scx_ops_bypass(bool bypass)
 {
@@ -3070,9 +3068,6 @@ static void scx_ops_bypass(bool bypass)
 		WARN_ON_ONCE(depth <= 0);
 		if (depth != 1)
 			return;
-
-		scx_ops.enqueue = scx_ops_fallback_enqueue;
-		scx_ops.dispatch = scx_ops_fallback_dispatch;
 	} else {
 		depth = atomic_dec_return(&scx_ops_bypass_depth);
 		WARN_ON_ONCE(depth < 0);
@@ -3086,7 +3081,7 @@ static void scx_ops_bypass(bool bypass)
 		if (READ_ONCE(p->__state) != TASK_DEAD) {
 			struct sched_enq_and_set_ctx ctx;
 
-			/* cycling deq/enq is enough, see above */
+			/* cycling deq/enq is enough, see the function comment */
 			sched_deq_and_put_task(p, DEQUEUE_SAVE | DEQUEUE_MOVE, &ctx);
 			sched_enq_and_set_task(&ctx);
 		}

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -4638,15 +4638,14 @@ static const struct btf_kfunc_id_set scx_kfunc_set_any = {
 
 __diag_pop();
 
-/*
- * This can't be done from init_sched_ext_class() as register_btf_kfunc_id_set()
- * needs most of the system to be up.
- */
-static int __init register_ext_kfuncs(void)
+static int __init scx_init(void)
 {
 	int ret;
 
 	/*
+	 * kfunc registration can't be done from init_sched_ext_class() as
+	 * register_btf_kfunc_id_set() needs most of the system to be up.
+	 *
 	 * Some kfuncs are context-sensitive and can only be called from
 	 * specific SCX ops. They are grouped into BTF sets accordingly.
 	 * Unfortunately, BPF currently doesn't have a way of enforcing such
@@ -4676,4 +4675,4 @@ static int __init register_ext_kfuncs(void)
 
 	return 0;
 }
-__initcall(register_ext_kfuncs);
+__initcall(scx_init);

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -495,7 +495,7 @@ static bool scx_ops_tryset_enable_state(enum scx_ops_enable_state to,
 	return atomic_try_cmpxchg(&scx_ops_enable_state_var, &from_v, to);
 }
 
-static bool scx_ops_disabling(void)
+static bool scx_ops_bypassing(void)
 {
 	return unlikely(scx_ops_enable_state() == SCX_OPS_DISABLING);
 }
@@ -1594,7 +1594,7 @@ static int balance_one(struct rq *rq, struct task_struct *prev,
 		 * same conditions later and pick @rq->curr accordingly.
 		 */
 		if ((prev->scx.flags & SCX_TASK_QUEUED) &&
-		    prev->scx.slice && !scx_ops_disabling()) {
+		    prev->scx.slice && !scx_ops_bypassing()) {
 			if (local)
 				prev->scx.flags |= SCX_TASK_BAL_KEEP;
 			return 1;
@@ -1787,7 +1787,7 @@ static void put_prev_task_scx(struct rq *rq, struct task_struct *p)
 		 * scheduler class or core-sched forcing a different task. Leave
 		 * it at the head of the local DSQ.
 		 */
-		if (p->scx.slice && !scx_ops_disabling()) {
+		if (p->scx.slice && !scx_ops_bypassing()) {
 			dispatch_enqueue(&rq->scx.local_dsq, p, SCX_ENQ_HEAD);
 			return;
 		}
@@ -1830,7 +1830,7 @@ static struct task_struct *pick_next_task_scx(struct rq *rq)
 		return NULL;
 
 	if (unlikely(!p->scx.slice)) {
-		if (!scx_ops_disabling() && !scx_warned_zero_slice) {
+		if (!scx_ops_bypassing() && !scx_warned_zero_slice) {
 			printk_deferred(KERN_WARNING "sched_ext: %s[%d] has zero slice in pick_next_task_scx()\n",
 					p->comm, p->pid);
 			scx_warned_zero_slice = true;
@@ -1869,7 +1869,7 @@ bool scx_prio_less(const struct task_struct *a, const struct task_struct *b,
 	 * calling ops.core_sched_before(). Accesses are controlled by the
 	 * verifier.
 	 */
-	if (SCX_HAS_OP(core_sched_before) && !scx_ops_disabling())
+	if (SCX_HAS_OP(core_sched_before) && !scx_ops_bypassing())
 		return SCX_CALL_OP_2TASKS_RET(SCX_KF_REST, core_sched_before,
 					      (struct task_struct *)a,
 					      (struct task_struct *)b);
@@ -2265,7 +2265,7 @@ static void task_tick_scx(struct rq *rq, struct task_struct *curr, int queued)
 	 * While disabling, always resched and refresh core-sched timestamp as
 	 * we can't trust the slice management or ops.core_sched_before().
 	 */
-	if (scx_ops_disabling()) {
+	if (scx_ops_bypassing()) {
 		curr->scx.slice = 0;
 		touch_core_sched(rq, curr);
 	}
@@ -2568,7 +2568,7 @@ bool scx_can_stop_tick(struct rq *rq)
 {
 	struct task_struct *p = rq->curr;
 
-	if (scx_ops_disabling())
+	if (scx_ops_bypassing())
 		return false;
 
 	if (p->sched_class != &ext_sched_class)
@@ -3017,7 +3017,7 @@ static void scx_cgroup_config_knobs(void) {}
  */
 bool task_should_scx(struct task_struct *p)
 {
-	if (!scx_enabled() || scx_ops_disabling())
+	if (!scx_enabled() || scx_ops_bypassing())
 		return false;
 	if (READ_ONCE(scx_switching_all))
 		return true;
@@ -3034,6 +3034,57 @@ static void scx_ops_fallback_enqueue(struct task_struct *p, u64 enq_flags)
 
 static void scx_ops_fallback_dispatch(s32 cpu, struct task_struct *prev) {}
 
+/**
+ * scx_ops_bypass - Bypass scx_ops and guarantee forward progress
+ *
+ * We must guarantee that all runnable tasks make forward progress without
+ * trusting the BPF scheduler. We can't grab any mutexes or rwsems as they might
+ * be held by tasks that the BPF scheduler is forgetting to run, which
+ * unfortunately also excludes toggling the static branches.
+ *
+ * Let's work around by overriding a couple ops and modifying behaviors based on
+ * the DISABLING state and then cycling the tasks through dequeue/enqueue to
+ * force global FIFO scheduling.
+ *
+ * a. ops.enqueue() and .dispatch() are overridden for simple global FIFO
+ *    scheduling.
+ *
+ * b. balance_scx() never sets %SCX_TASK_BAL_KEEP as the slice value can't be
+ *    trusted. Whenever a tick triggers, the running task is rotated to the tail
+ *    of the queue with core_sched_at touched.
+ *
+ * c. pick_next_task() suppresses zero slice warning.
+ *
+ * d. scx_prio_less() reverts to the default core_sched_at order.
+ */
+static void scx_ops_bypass(void)
+{
+	struct scx_task_iter sti;
+	struct task_struct *p;
+	int cpu;
+
+	scx_ops.enqueue = scx_ops_fallback_enqueue;
+	scx_ops.dispatch = scx_ops_fallback_dispatch;
+
+	spin_lock_irq(&scx_tasks_lock);
+	scx_task_iter_init(&sti);
+	while ((p = scx_task_iter_next_filtered_locked(&sti))) {
+		if (READ_ONCE(p->__state) != TASK_DEAD) {
+			struct sched_enq_and_set_ctx ctx;
+
+			/* cycling deq/enq is enough, see above */
+			sched_deq_and_put_task(p, DEQUEUE_SAVE | DEQUEUE_MOVE, &ctx);
+			sched_enq_and_set_task(&ctx);
+		}
+	}
+	scx_task_iter_exit(&sti);
+	spin_unlock_irq(&scx_tasks_lock);
+
+	/* kick all CPUs to restore ticks */
+	for_each_possible_cpu(cpu)
+		resched_cpu(cpu);
+}
+
 static void scx_ops_disable_workfn(struct kthread_work *work)
 {
 	struct scx_exit_info *ei = &scx_exit_info;
@@ -3042,7 +3093,7 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 	struct rhashtable_iter rht_iter;
 	struct scx_dispatch_q *dsq;
 	const char *reason;
-	int i, cpu, kind;
+	int i, kind;
 
 	kind = atomic_read(&scx_exit_kind);
 	while (true) {
@@ -3090,63 +3141,17 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 			     SCX_OPS_DISABLING);
 		return;
 	case SCX_OPS_PREPPING:
-		goto forward_progress_guaranteed;
+		break;
 	case SCX_OPS_DISABLING:
 		/* shouldn't happen but handle it like ENABLING if it does */
 		WARN_ONCE(true, "sched_ext: duplicate disabling instance?");
 		fallthrough;
 	case SCX_OPS_ENABLING:
 	case SCX_OPS_ENABLED:
+		scx_ops_bypass();
 		break;
 	}
 
-	/*
-	 * DISABLING is set and ops was either ENABLING or ENABLED indicating
-	 * that the ops and static branches are set.
-	 *
-	 * We must guarantee that all runnable tasks make forward progress
-	 * without trusting the BPF scheduler. We can't grab any mutexes or
-	 * rwsems as they might be held by tasks that the BPF scheduler is
-	 * forgetting to run, which unfortunately also excludes toggling the
-	 * static branches.
-	 *
-	 * Let's work around by overriding a couple ops and modifying behaviors
-	 * based on the DISABLING state and then cycling the tasks through
-	 * dequeue/enqueue to force global FIFO scheduling.
-	 *
-	 * a. ops.enqueue() and .dispatch() are overridden for simple global
-	 *    FIFO scheduling.
-	 *
-	 * b. balance_scx() never sets %SCX_TASK_BAL_KEEP as the slice value
-	 *    can't be trusted. Whenever a tick triggers, the running task is
-	 *    rotated to the tail of the queue with core_sched_at touched.
-	 *
-	 * c. pick_next_task() suppresses zero slice warning.
-	 *
-	 * d. scx_prio_less() reverts to the default core_sched_at order.
-	 */
-	scx_ops.enqueue = scx_ops_fallback_enqueue;
-	scx_ops.dispatch = scx_ops_fallback_dispatch;
-
-	spin_lock_irq(&scx_tasks_lock);
-	scx_task_iter_init(&sti);
-	while ((p = scx_task_iter_next_filtered_locked(&sti))) {
-		if (READ_ONCE(p->__state) != TASK_DEAD) {
-			struct sched_enq_and_set_ctx ctx;
-
-			/* cycling deq/enq is enough, see above */
-			sched_deq_and_put_task(p, DEQUEUE_SAVE | DEQUEUE_MOVE, &ctx);
-			sched_enq_and_set_task(&ctx);
-		}
-	}
-	scx_task_iter_exit(&sti);
-	spin_unlock_irq(&scx_tasks_lock);
-
-	/* kick all CPUs to restore ticks */
-	for_each_possible_cpu(cpu)
-		resched_cpu(cpu);
-
-forward_progress_guaranteed:
 	/*
 	 * Here, every runnable task is guaranteed to make forward progress and
 	 * we can safely use blocking synchronization constructs. Actually

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3606,6 +3606,7 @@ static int scx_debug_show(struct seq_file *m, void *v)
 	seq_printf(m, "%-30s: %ld\n", "switched_all", scx_switched_all());
 	seq_printf(m, "%-30s: %s\n", "enable_state",
 		   scx_ops_enable_state_str[scx_ops_enable_state()]);
+	seq_printf(m, "%-30s: %d\n", "bypassing", scx_ops_bypassing());
 	seq_printf(m, "%-30s: %lu\n", "nr_rejected",
 		   atomic_long_read(&scx_nr_rejected));
 	mutex_unlock(&scx_ops_enable_mutex);

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -962,9 +962,16 @@ static bool task_runnable(const struct task_struct *p)
 static void set_task_runnable(struct rq *rq, struct task_struct *p)
 {
 	lockdep_assert_rq_held(rq);
-	if (p->scx.flags & SCX_TASK_RESET_RUNNABLE_AT)
+
+	if (p->scx.flags & SCX_TASK_RESET_RUNNABLE_AT) {
 		p->scx.runnable_at = jiffies;
-	p->scx.flags &= ~SCX_TASK_RESET_RUNNABLE_AT;
+		p->scx.flags &= ~SCX_TASK_RESET_RUNNABLE_AT;
+	}
+
+	/*
+	 * list_add_tail() must be used. scx_ops_bypass() depends on tasks being
+	 * appened to the runnable_list.
+	 */
 	list_add_tail(&p->scx.runnable_node, &rq->scx.runnable_list);
 }
 
@@ -3042,8 +3049,8 @@ bool task_should_scx(struct task_struct *p)
  * unfortunately also excludes toggling the static branches.
  *
  * Let's work around by overriding a couple ops and modifying behaviors based on
- * the DISABLING state and then cycling the tasks through dequeue/enqueue to
- * force global FIFO scheduling.
+ * the DISABLING state and then cycling the queued tasks through dequeue/enqueue
+ * to force global FIFO scheduling.
  *
  * a. ops.enqueue() is ignored and tasks are queued in simple global FIFO order.
  *
@@ -3059,8 +3066,6 @@ bool task_should_scx(struct task_struct *p)
  */
 static void scx_ops_bypass(bool bypass)
 {
-	struct scx_task_iter sti;
-	struct task_struct *p;
 	int depth, cpu;
 
 	if (bypass) {
@@ -3075,23 +3080,43 @@ static void scx_ops_bypass(bool bypass)
 			return;
 	}
 
-	spin_lock_irq(&scx_tasks_lock);
-	scx_task_iter_init(&sti);
-	while ((p = scx_task_iter_next_filtered_locked(&sti))) {
-		if (READ_ONCE(p->__state) != TASK_DEAD) {
+	/*
+	 * No task property is changing. We just need to make sure all currently
+	 * queued tasks are re-queued according to the new scx_ops_bypassing()
+	 * state. As an optimization, walk each rq's runnable_list instead of
+	 * the scx_tasks list.
+	 *
+	 * This function can't trust the scheduler and thus can't use
+	 * cpus_read_lock(). Walk all possible CPUs instead of online.
+	 */
+	for_each_possible_cpu(cpu) {
+		struct rq *rq = cpu_rq(cpu);
+		struct rq_flags rf;
+		struct task_struct *p, *n;
+
+		rq_lock_irqsave(rq, &rf);
+
+		/*
+		 * The use of list_for_each_entry_safe_reverse() is required
+		 * because each task is going to be removed from and added back
+		 * to the runnable_list during iteration. Because they're added
+		 * to the tail of the list, safe reverse iteration can still
+		 * visit all nodes.
+		 */
+		list_for_each_entry_safe_reverse(p, n, &rq->scx.runnable_list,
+						 scx.runnable_node) {
 			struct sched_enq_and_set_ctx ctx;
 
 			/* cycling deq/enq is enough, see the function comment */
 			sched_deq_and_put_task(p, DEQUEUE_SAVE | DEQUEUE_MOVE, &ctx);
 			sched_enq_and_set_task(&ctx);
 		}
-	}
-	scx_task_iter_exit(&sti);
-	spin_unlock_irq(&scx_tasks_lock);
 
-	/* kick all CPUs to restore ticks */
-	for_each_possible_cpu(cpu)
+		rq_unlock_irqrestore(rq, &rf);
+
+		/* kick to restore ticks */
 		resched_cpu(cpu);
+	}
 }
 
 static void scx_ops_disable_workfn(struct kthread_work *work)

--- a/kernel/sched/ext.h
+++ b/kernel/sched/ext.h
@@ -163,8 +163,9 @@ static inline void scx_notify_sched_tick(void)
 	if (!scx_enabled())
 		return;
 
-	last_check = scx_watchdog_timestamp;
-	if (unlikely(time_after(jiffies, last_check + scx_watchdog_timeout))) {
+	last_check = READ_ONCE(scx_watchdog_timestamp);
+	if (unlikely(time_after(jiffies,
+				last_check + READ_ONCE(scx_watchdog_timeout)))) {
 		u32 dur_ms = jiffies_to_msecs(jiffies - last_check);
 
 		scx_ops_error_kind(SCX_EXIT_ERROR_STALL,

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -690,7 +690,7 @@ enum scx_rq_flags {
 
 struct scx_rq {
 	struct scx_dispatch_q	local_dsq;
-	struct list_head	watchdog_list;
+	struct list_head	runnable_list;		/* runnable tasks on this rq */
 	unsigned long		ops_qseq;
 	u64			extra_enq_flags;	/* see move_task_to_local_dsq() */
 	u32			nr_running;


### PR DESCRIPTION
#102 reports that `scx_userland` and `scx_rustland` trigger stall failure on system suspend attempts. The problem is that these schedulers need userspace running for scheduling to work. Because during suspend and other PM operations, all user and some kernel threads are frozen during preparation, scheduling stops working triggering either freezer timeout or scx watchdog.

In #102, @arighi worked around by preemptively ejecting the sched_ext scheduler. While it's possible to implement userspace hooks to reload the scheduler after PM operations are finished, it's rather inconvenient and unnecessary. In terms of scheduling, there isn't anything interesting happening while the PM operations are in progress, so all we need to do is not stalling the system.

In the ops disabling path, we're already doing something similar. Because we can't trust the scheduler, we override SCX into global FIFO mode before taking any actions which may require working scheduling. This PR

- Factors out the forced FIFO behavior in the disabling path and generalizes it into bypass mode.
- Optimize bypass mode so that it doesn't involve iterating all tasks in the system.
- Enables bypass mode while PM operations are in progress so that the system guarantees forward progress regardless of whether the SCX scheduler depends on userspace or not.