### PR TITLE
Fix fallback

### DIFF
--- a/tools/testing/selftests/scx/.gitignore
+++ b/tools/testing/selftests/scx/.gitignore
@@ -1,3 +1,5 @@
+dsp_fallbackdsq_fail
+dsp_localdsq_fail
 enq_last_no_enq_fails
 enqueue_select_cpu_fails
 minimal

--- a/tools/testing/selftests/scx/Makefile
+++ b/tools/testing/selftests/scx/Makefile
@@ -155,7 +155,9 @@ c-sched-targets :=			\
 	select_cpu_dispatch_dbl_dsp	\
 	select_cpu_dispatch_bad_dsq	\
 	enqueue_select_cpu_fails	\
-	enq_last_no_enq_fails
+	enq_last_no_enq_fails		\
+	dsp_localdsq_fail		\
+	dsp_fallbackdsq_fail
 
 $(c-sched-targets): %: $(filter-out %.bpf.c,%.c) $(INCLUDE_DIR)/%.bpf.skel.h
 	$(eval sched=$(notdir $@))

--- a/tools/testing/selftests/scx/dsp_fallbackdsq_fail.bpf.c
+++ b/tools/testing/selftests/scx/dsp_fallbackdsq_fail.bpf.c
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2024 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2024 David Vernet <dvernet@meta.com>
+ * Copyright (c) 2024 Tejun Heo <tj@kernel.org>
+ */
+#include <scx/common.bpf.h>
+
+char _license[] SEC("license") = "GPL";
+
+s32 BPF_STRUCT_OPS(dsp_fallbackdsq_fail_select_cpu, struct task_struct *p,
+		   s32 prev_cpu, u64 wake_flags)
+{
+	s32 cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+
+	if (cpu >= 0) {
+		/*
+		 * If we dispatch to a bogus DSQ that will fall back to the
+		 * builtin global DSQ, we fail gracefully.
+		 */
+		scx_bpf_dispatch_vtime(p, 0xcafef00d, SCX_SLICE_DFL,
+				       p->scx.dsq_vtime, 0);
+		return cpu;
+	}
+
+	return prev_cpu;
+}
+
+s32 BPF_STRUCT_OPS(dsp_fallbackdsq_fail_init)
+{
+	scx_bpf_switch_all();
+
+	return 0;
+}
+
+SEC(".struct_ops.link")
+struct sched_ext_ops dsp_fallbackdsq_fail_ops = {
+	.select_cpu		= dsp_fallbackdsq_fail_select_cpu,
+	.init			= dsp_fallbackdsq_fail_init,
+	.name			= "dsp_fallbackdsq_fail",
+	.timeout_ms		= 1000U,
+};

--- a/tools/testing/selftests/scx/dsp_fallbackdsq_fail.c
+++ b/tools/testing/selftests/scx/dsp_fallbackdsq_fail.c
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2024 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2024 David Vernet <dvernet@meta.com>
+ * Copyright (c) 2024 Tejun Heo <tj@kernel.org>
+ */
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <libgen.h>
+#include <bpf/bpf.h>
+#include <scx/common.h>
+#include <sys/wait.h>
+#include "dsp_fallbackdsq_fail.bpf.skel.h"
+#include "scx_test.h"
+
+int main(int argc, char **argv)
+{
+	struct dsp_fallbackdsq_fail *skel;
+	struct bpf_link *link;
+
+	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
+	skel = dsp_fallbackdsq_fail__open_and_load();
+	SCX_BUG_ON(!skel, "Failed to open and load skel");
+
+	link = bpf_map__attach_struct_ops(skel->maps.dsp_fallbackdsq_fail_ops);
+	SCX_BUG_ON(!link, "Failed to attach struct_ops");
+
+	sleep(1);
+
+	bpf_link__destroy(link);
+	dsp_fallbackdsq_fail__destroy(skel);
+
+	return 0;
+}


### PR DESCRIPTION
We're currently checking whether a builtin DSQ is being used with priq
in scx_bpf_dispatch_vtime(). This neglects the fact that we could end up
falling back to scx_dsq_global if there's an error. If we error out with
SCX_ENQ_DSQ_PRIQ set in enqueue flags, we would trigger a warning in
dispatch_enqueue(). Let's instead just move the check to inside of
dispatch_enqueue().