### PR TITLE
Claim idle core in scx_select_cpu_dfl for nr_cpus_allowed ==1

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -2048,8 +2048,14 @@ static s32 scx_select_cpu_dfl(struct task_struct *p, s32 prev_cpu,
 			goto cpu_found;
 	}
 
-	if (p->nr_cpus_allowed == 1)
-		return prev_cpu;
+	if (p->nr_cpus_allowed == 1) {
+		if (test_and_clear_cpu_idle(prev_cpu)) {
+			cpu = prev_cpu;
+			goto cpu_found;
+		} else {
+			return prev_cpu;
+		}
+	}
 
 	/*
 	 * If CPU has SMT, any wholly idle CPU is likely a better pick than


### PR DESCRIPTION
    In scx_select_cpu_dfl(), we're currently returning prev_cpu if
    p->nr_cpus_allowed == 1. It makes sense to return prev_cpu if the task
    can't run on any other cores, but we might as well also try to claim the
    core as idle so that:
     
    1. scx_select_cpu_dfl() will directly dispatch it
    2. To prevent another core from incorrectly assuming that core will be
       idle when in reality that task will be enqueued to it. The mask will
       eventually be updated in __scx_update_idle(), but this seems more
       efficient.
    3. To have the idle cpumask bit be unset when the task is enqueued in
       ops.enqueue() (if the core scheduler is using
       scx_bpf_select_cpu_dfl()).