### PR TITLE
scx: Set default slice for default select_cpu dispatch

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -2124,8 +2124,10 @@ static int select_task_rq_scx(struct task_struct *p, int prev_cpu, int wake_flag
 		s32 cpu;
 
 		cpu = scx_select_cpu_dfl(p, prev_cpu, wake_flags, &found);
-		if (found)
+		if (found) {
+			p->scx.slice = SCX_SLICE_DFL;
 			p->scx.ddsq_id = SCX_DSQ_LOCAL;
+		}
 		return cpu;
 	}
 }


### PR DESCRIPTION
If ops.select_cpu() isn't defined, scx_select_cpu_dfl() will be called, and a task will be dispatched directly to a core if one is found. I neglected to also set the task slice, so we see the following warning if we use the direct dispatch:

[root@arch scx]# ./select_cpu_dfl
[   23.184426] sched_ext: select_cpu_dfl[356] has zero slice in pick_next_task_scx()

I'm not sure why this wasn't being printed when I tested this before, but let's fix it.