### PR TITLE
Make the pionter passing to .dispatch MAYBE_NULL

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3666,15 +3666,75 @@ const struct file_operations sched_ext_fops = {
 
 extern struct btf *btf_vmlinux;
 static const struct btf_type *task_struct_type;
+static u32 task_struct_type_id;
+
+/* Make the 2nd argument of .dispatch a pointer that can be NULL. */
+static bool promote_dispatch_2nd_arg(int off, int size,
+                                     enum bpf_access_type type,
+                                     const struct bpf_prog *prog,
+                                     struct bpf_insn_access_aux *info)
+{
+	const struct bpf_struct_ops *st_ops;
+	const struct btf_member *member;
+        const struct btf_type *t;
+        u32 btf_id, member_idx;
+	const char *mname;
+
+        /* btf_id should be the type id of struct sched_ext_ops */
+	btf_id = prog->aux->attach_btf_id;
+	st_ops = bpf_struct_ops_find(btf_id);
+	if (!st_ops)
+                return false;
+
+        /* BTF type of struct sched_ext_ops */
+        t = st_ops->type;
+
+	member_idx = prog->expected_attach_type;
+	if (member_idx >= btf_type_vlen(t))
+                return false;
+
+        /* Get the member name of this program.  For example, the
+         * member name of the dispatch program is "dispatch".
+         */
+	member = &btf_type_member(t)[member_idx];
+	mname = btf_name_by_offset(btf_vmlinux, member->name_off);
+
+        /* Chkeck if it is the 2nd argument of the function pointer at
+         * "dispatch" in struct sched_ext_ops. The arguments of
+         * struct_ops operators are placed in the context one after
+         * another. And, they are 64-bits. So, the 2nd argument is at
+         * offset sizeof(__u64).
+         */
+        if (strcmp(mname, "dispatch") == 0 &&
+            off == sizeof(__u64)) {
+                /* The value is a pointer to a type (struct
+                 * task_struct) given by a BTF ID (PTR_TO_BTF_ID). It
+                 * is tursted (PTR_TRUSTED), however, can be a NULL
+                 * (PTR_MAYBE_NULL).  The BPF program should check the
+                 * pointer to make sure it is not null before using
+                 * it, or the verifier will reject the program.
+                 */
+                info->reg_type = PTR_MAYBE_NULL | PTR_TO_BTF_ID |
+                  PTR_TRUSTED;
+                info->btf = btf_vmlinux;
+                info->btf_id = task_struct_type_id;
+
+                return true;
+        }
+
+        return false;
+}
 
 static bool bpf_scx_is_valid_access(int off, int size,
 				    enum bpf_access_type type,
 				    const struct bpf_prog *prog,
 				    struct bpf_insn_access_aux *info)
 {
-	if (off < 0 || off >= sizeof(__u64) * MAX_BPF_FUNC_ARGS)
-		return false;
 	if (type != BPF_READ)
+		return false;
+        if (promote_dispatch_2nd_arg(off, size, type, prog, info))
+                return true;
+	if (off < 0 || off >= sizeof(__u64) * MAX_BPF_FUNC_ARGS)
 		return false;
 	if (off % size != 0)
 		return false;
@@ -3804,6 +3864,7 @@ static int bpf_scx_init(struct btf *btf)
 	if (type_id < 0)
 		return -EINVAL;
 	task_struct_type = btf_type_by_id(btf, type_id);
+        task_struct_type_id = type_id;
 
 	return 0;
 }

--- a/tools/testing/selftests/scx/Makefile
+++ b/tools/testing/selftests/scx/Makefile
@@ -161,6 +161,7 @@ auto-test-targets :=			\
 	ddsp_bogus_dsq_fail		\
 	ddsp_vtimelocal_fail		\
 	init_enable_count		\
+	maybe_null			\
 	minimal				\
 	select_cpu_dfl			\
 	select_cpu_dfl_nodispatch	\
@@ -175,6 +176,8 @@ testcase-targets := $(addsuffix .o,$(addprefix $(SCXOBJ_DIR)/,$(auto-test-target
 $(SCXOBJ_DIR)/runner.o: runner.c | $(SCXOBJ_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
+$(SCXOBJ_DIR)/maybe_null.o: $(INCLUDE_DIR)/maybe_null_fail.bpf.skel.h
+
 # Create all of the test targets object files, whose testcase objects will be
 # registered into the runner in ELF constructors.
 #
@@ -188,7 +191,7 @@ $(testcase-targets): $(SCXOBJ_DIR)/%.o: %.c $(SCXOBJ_DIR)/runner.o $$(if $$(wild
 
 runner: $(SCXOBJ_DIR)/runner.o $(BPFOBJ) $(testcase-targets)
 	@echo "$(testcase-targets)"
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 TEST_GEN_PROGS := runner
 

--- a/tools/testing/selftests/scx/maybe_null.bpf.c
+++ b/tools/testing/selftests/scx/maybe_null.bpf.c
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <scx/common.bpf.h>
+
+char _license[] SEC("license") = "GPL";
+
+u64 vtime_test;
+
+void BPF_STRUCT_OPS(maybe_null_running, struct task_struct *p)
+{}
+
+void BPF_STRUCT_OPS(maybe_null_success_dispatch, s32 cpu, struct task_struct *p)
+{
+        if (p != NULL)
+          vtime_test = p->scx.dsq_vtime;
+}
+
+SEC(".struct_ops.link")
+struct sched_ext_ops maybe_null_success = {
+        .dispatch               = maybe_null_success_dispatch,
+	.enable			= maybe_null_running,
+	.name			= "minimal",
+};

--- a/tools/testing/selftests/scx/maybe_null.c
+++ b/tools/testing/selftests/scx/maybe_null.c
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2023 David Vernet <dvernet@meta.com>
+ * Copyright (c) 2023 Tejun Heo <tj@kernel.org>
+ */
+#include <bpf/bpf.h>
+#include <scx/common.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "maybe_null.bpf.skel.h"
+#include "maybe_null_fail.bpf.skel.h"
+#include "scx_test.h"
+
+static enum scx_test_status run(void *ctx)
+{
+        struct maybe_null *skel;
+        struct maybe_null_fail *fail_skel;
+
+        skel = maybe_null__open_and_load();
+        if (!skel) {
+                SCX_ERR("Failed to open and load maybe_null skel");
+                return SCX_TEST_FAIL;
+        }
+        maybe_null__destroy(skel);
+
+        fail_skel = maybe_null_fail__open_and_load();
+        if (fail_skel) {
+                maybe_null_fail__destroy(fail_skel);
+                SCX_ERR("Should failed to open and load maybe_null_fail skel");
+                return SCX_TEST_FAIL;
+        }
+
+	return SCX_TEST_PASS;
+}
+
+struct scx_test maybe_null = {
+	.name = "maybe_null",
+	.description = "Verify if PTR_MAYBE_NULL work for .dispatch",
+	.run = run,
+};
+REGISTER_SCX_TEST(&maybe_null)

--- a/tools/testing/selftests/scx/maybe_null_fail.bpf.c
+++ b/tools/testing/selftests/scx/maybe_null_fail.bpf.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <scx/common.bpf.h>
+
+char _license[] SEC("license") = "GPL";
+
+u64 vtime_test;
+
+void BPF_STRUCT_OPS(maybe_null_running, struct task_struct *p)
+{}
+
+void BPF_STRUCT_OPS(maybe_null_fail_dispatch, s32 cpu, struct task_struct *p)
+{
+          vtime_test = p->scx.dsq_vtime;
+}
+
+SEC(".struct_ops.link")
+struct sched_ext_ops maybe_null_fail = {
+        .dispatch               = maybe_null_fail_dispatch,
+	.enable			= maybe_null_running,
+	.name			= "minimal",
+};

--- a/tools/testing/selftests/scx/runner.c
+++ b/tools/testing/selftests/scx/runner.c
@@ -55,6 +55,8 @@ static const char *status_to_result(enum scx_test_status status)
 	case SCX_TEST_FAIL:
 		return "not ok";
 	}
+
+        return NULL;
 }
 
 static void print_test_result(const struct scx_test *test,


### PR DESCRIPTION
This patch marks the second argument of .dispatch with
PTR_MAYBE_NULL | PTR_TO_BTF_ID | PTR_TRUSTED in
bpf_scx_is_valid_access(). The verifier  will ensures the programs
always check if the argument is NULL before reading the pointed memory.