### PR TITLE
scx: Replace /sys/kernel/debug/sched/ext with /sys/kernel/sched_ext

### DIFF
--- a/Documentation/scheduler/sched-ext.rst
+++ b/Documentation/scheduler/sched-ext.rst
@@ -51,17 +51,17 @@ BPF scheduler and reverts all tasks back to CFS.
     local=17 global=72
     ^CEXIT: BPF scheduler unregistered
 
-If ``CONFIG_SCHED_DEBUG`` is set, the current status of the BPF scheduler
-and whether a given task is on sched_ext can be determined as follows:
+The current status of the BPF scheduler can be determined as follows:
 
 .. code-block:: none
 
-    # cat /sys/kernel/debug/sched/ext
-    ops                           : simple
-    enabled                       : 1
-    switching_all                 : 1
-    switched_all                  : 1
-    enable_state                  : enabled
+    # cat /sys/kernel/sched_ext/state
+    enabled
+    # cat /sys/kernel/sched_ext/root/ops
+    simple
+
+If ``CONFIG_SCHED_DEBUG`` is set, whether a given task is on sched_ext can
+be determined as follows:
 
     # grep ext /proc/self/sched
     ext.enabled                                  :                    1

--- a/Documentation/scheduler/sched-ext.rst
+++ b/Documentation/scheduler/sched-ext.rst
@@ -60,8 +60,24 @@ The current status of the BPF scheduler can be determined as follows:
     # cat /sys/kernel/sched_ext/root/ops
     simple
 
+``tools/sched_ext/scx_show_state.py`` is a drgn script which shows more
+detailed information:
+
+.. code-block:: none
+
+    # tools/sched_ext/scx_show_state.py
+    ops           : simple
+    enabled       : 1
+    switching_all : 1
+    switched_all  : 1
+    enable_state  : enabled (2)
+    bypass_depth  : 0
+    nr_rejected   : 0
+
 If ``CONFIG_SCHED_DEBUG`` is set, whether a given task is on sched_ext can
 be determined as follows:
+
+.. code-block:: none
 
     # grep ext /proc/self/sched
     ext.enabled                                  :                    1

--- a/kernel/sched/build_policy.c
+++ b/kernel/sched/build_policy.c
@@ -21,6 +21,7 @@
 
 #include <linux/cpuidle.h>
 #include <linux/jiffies.h>
+#include <linux/kobject.h>
 #include <linux/livepatch.h>
 #include <linux/pm.h>
 #include <linux/psi.h>

--- a/kernel/sched/debug.c
+++ b/kernel/sched/debug.c
@@ -374,9 +374,6 @@ static __init int sched_init_debug(void)
 
 	debugfs_create_file("debug", 0444, debugfs_sched, NULL, &sched_debug_fops);
 
-#ifdef CONFIG_SCHED_CLASS_EXT
-	debugfs_create_file("ext", 0444, debugfs_sched, NULL, &sched_ext_fops);
-#endif
 	return 0;
 }
 late_initcall(sched_init_debug);

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3724,37 +3724,6 @@ err_disable:
 	return ret;
 }
 
-#ifdef CONFIG_SCHED_DEBUG
-static int scx_debug_show(struct seq_file *m, void *v)
-{
-	mutex_lock(&scx_ops_enable_mutex);
-	seq_printf(m, "%-30s: %s\n", "ops", scx_ops.name);
-	seq_printf(m, "%-30s: %ld\n", "enabled", scx_enabled());
-	seq_printf(m, "%-30s: %d\n", "switching_all",
-		   READ_ONCE(scx_switching_all));
-	seq_printf(m, "%-30s: %ld\n", "switched_all", scx_switched_all());
-	seq_printf(m, "%-30s: %s\n", "enable_state",
-		   scx_ops_enable_state_str[scx_ops_enable_state()]);
-	seq_printf(m, "%-30s: %d\n", "bypassing", scx_ops_bypassing());
-	seq_printf(m, "%-30s: %lu\n", "nr_rejected",
-		   atomic_long_read(&scx_nr_rejected));
-	mutex_unlock(&scx_ops_enable_mutex);
-	return 0;
-}
-
-static int scx_debug_open(struct inode *inode, struct file *file)
-{
-	return single_open(file, scx_debug_show, NULL);
-}
-
-const struct file_operations sched_ext_fops = {
-	.open		= scx_debug_open,
-	.read		= seq_read,
-	.llseek		= seq_lseek,
-	.release	= single_release,
-};
-#endif
-
 
 /********************************************************************************
  * bpf_struct_ops plumbing.

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -193,6 +193,10 @@ struct scx_dsp_ctx {
 
 static DEFINE_PER_CPU(struct scx_dsp_ctx, scx_dsp_ctx);
 
+/* /sys/kernel/sched_ext interface */
+static struct kset *scx_kset;
+static struct kobject *scx_root_kobj;
+
 void scx_bpf_dispatch(struct task_struct *p, u64 dsq_id, u64 slice,
 		      u64 enq_flags);
 void scx_bpf_kick_cpu(s32 cpu, u64 flags);
@@ -3030,6 +3034,83 @@ static int scx_cgroup_init(void) { return 0; }
 static void scx_cgroup_config_knobs(void) {}
 #endif
 
+
+/********************************************************************************
+ * Sysfs interface and ops enable/disable.
+ */
+
+#define SCX_ATTR(_name)								\
+	static struct kobj_attribute scx_attr_##_name = {			\
+		.attr = { .name = __stringify(_name), .mode = 0444 },		\
+		.show = scx_attr_##_name##_show,				\
+	}
+
+static ssize_t scx_attr_state_show(struct kobject *kobj,
+				   struct kobj_attribute *ka, char *buf)
+{
+	return sysfs_emit(buf, "%s\n",
+			  scx_ops_enable_state_str[scx_ops_enable_state()]);
+}
+SCX_ATTR(state);
+
+static ssize_t scx_attr_switch_all_show(struct kobject *kobj,
+					struct kobj_attribute *ka, char *buf)
+{
+	return sysfs_emit(buf, "%d\n", READ_ONCE(scx_switching_all));
+}
+SCX_ATTR(switch_all);
+
+static ssize_t scx_attr_nr_rejected_show(struct kobject *kobj,
+					 struct kobj_attribute *ka, char *buf)
+{
+	return sysfs_emit(buf, "%ld\n", atomic_long_read(&scx_nr_rejected));
+}
+SCX_ATTR(nr_rejected);
+
+static struct attribute *scx_global_attrs[] = {
+	&scx_attr_state.attr,
+	&scx_attr_switch_all.attr,
+	&scx_attr_nr_rejected.attr,
+	NULL,
+};
+
+static const struct attribute_group scx_global_attr_group = {
+	.attrs = scx_global_attrs,
+};
+
+static void scx_kobj_release(struct kobject *kobj)
+{
+	kfree(kobj);
+}
+
+static ssize_t scx_attr_ops_show(struct kobject *kobj,
+				 struct kobj_attribute *ka, char *buf)
+{
+	return sysfs_emit(buf, "%s\n", scx_ops.name);
+}
+SCX_ATTR(ops);
+
+static struct attribute *scx_sched_attrs[] = {
+	&scx_attr_ops.attr,
+	NULL,
+};
+ATTRIBUTE_GROUPS(scx_sched);
+
+static const struct kobj_type scx_ktype = {
+	.release = scx_kobj_release,
+	.sysfs_ops = &kobj_sysfs_ops,
+	.default_groups = scx_sched_groups,
+};
+
+static int scx_uevent(const struct kobject *kobj, struct kobj_uevent_env *env)
+{
+	return add_uevent_var(env, "SCXOPS=%s", scx_ops.name);
+}
+
+static const struct kset_uevent_ops scx_uevent_ops = {
+	.uevent = scx_uevent,
+};
+
 /*
  * Used by sched_fork() and __setscheduler_prio() to pick the matching
  * sched_class. dl/rt are already handled.
@@ -3264,6 +3345,9 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 	if (scx_ops.exit)
 		SCX_CALL_OP(SCX_KF_UNLOCKED, exit, ei);
 
+	kobject_del(scx_root_kobj);
+	scx_root_kobj = NULL;
+
 	memset(&scx_ops, 0, sizeof(scx_ops));
 
 	rhashtable_walk_enter(&dsq_hash, &rht_iter);
@@ -3389,6 +3473,17 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 		ret = -EBUSY;
 		goto err;
 	}
+
+	scx_root_kobj = kzalloc(sizeof(*scx_root_kobj), GFP_KERNEL);
+	if (!scx_root_kobj) {
+		ret = -ENOMEM;
+		goto err;
+	}
+
+	scx_root_kobj->kset = scx_kset;
+	ret = kobject_init_and_add(scx_root_kobj, &scx_ktype, NULL, "root");
+	if (ret < 0)
+		goto err;
 
 	/*
 	 * Set scx_ops, transition to PREPPING and clear exit info to arm the
@@ -3603,6 +3698,7 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 	if (scx_switch_all_req)
 		static_branch_enable(&__scx_switched_all);
 
+	kobject_uevent(scx_root_kobj, KOBJ_ADD);
 	mutex_unlock(&scx_ops_enable_mutex);
 
 	scx_cgroup_config_knobs();
@@ -3610,6 +3706,8 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 	return 0;
 
 err:
+	kfree(scx_root_kobj);
+	scx_root_kobj = NULL;
 	mutex_unlock(&scx_ops_enable_mutex);
 	return ret;
 
@@ -3656,6 +3754,7 @@ const struct file_operations sched_ext_fops = {
 	.release	= single_release,
 };
 #endif
+
 
 /********************************************************************************
  * bpf_struct_ops plumbing.
@@ -3840,6 +3939,11 @@ struct bpf_struct_ops bpf_sched_ext_ops = {
 	.name = "sched_ext_ops",
 };
 
+
+/********************************************************************************
+ * System integration and init.
+ */
+
 static void sysrq_handle_sched_ext_reset(u8 key)
 {
 	if (scx_ops_helper)
@@ -3939,7 +4043,7 @@ void print_scx_info(const char *log_lvl, struct task_struct *p)
 		scnprintf(runnable_at_buf, sizeof(runnable_at_buf), "%+lldms",
 			  (s64)(runnable_at - jiffies) * (HZ / MSEC_PER_SEC));
 
-	/* Print everything onto one line to conserve console spce. */
+	/* print everything onto one line to conserve console space */
 	printk("%sSched_ext: %s (%s%s), task: runnable_at=%s",
 	       log_lvl, scx_ops.name, scx_ops_enable_state_str[state], all,
 	       runnable_at_buf);
@@ -4751,8 +4855,22 @@ static int __init scx_init(void)
 	}
 
 	ret = register_pm_notifier(&scx_pm_notifier);
-	if (ret)
-		pr_warn("sched_ext: Failed to register PM notifier (%d)\n", ret);
+	if (ret) {
+		pr_err("sched_ext: Failed to register PM notifier (%d)\n", ret);
+		return ret;
+	}
+
+	scx_kset = kset_create_and_add("sched_ext", &scx_uevent_ops, kernel_kobj);
+	if (!scx_kset) {
+		pr_err("sched_ext: Failed to create /sys/sched_ext\n");
+		return -ENOMEM;
+	}
+
+	ret = sysfs_create_group(&scx_kset->kobj, &scx_global_attr_group);
+	if (ret < 0) {
+		pr_err("sched_ext: Failed to add global attributes\n");
+		return ret;
+	}
 
 	return 0;
 }

--- a/kernel/sched/ext.h
+++ b/kernel/sched/ext.h
@@ -103,7 +103,6 @@ void sched_enq_and_set_task(struct sched_enq_and_set_ctx *ctx);
 
 extern const struct sched_class ext_sched_class;
 extern const struct bpf_verifier_ops bpf_sched_ext_verifier_ops;
-extern const struct file_operations sched_ext_fops;
 extern unsigned long scx_watchdog_timeout;
 extern unsigned long scx_watchdog_timestamp;
 

--- a/tools/sched_ext/scx_show_state.py
+++ b/tools/sched_ext/scx_show_state.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env drgn
+#
+# Copyright (C) 2024 Tejun Heo <tj@kernel.org>
+# Copyright (C) 2024 Meta Platforms, Inc. and affiliates.
+
+desc = """
+This is a drgn script to show the current sched_ext state.
+For more info on drgn, visit https://github.com/osandov/drgn.
+"""
+
+import drgn
+import sys
+
+def err(s):
+    print(s, file=sys.stderr, flush=True)
+    sys.exit(1)
+
+def read_int(name):
+    return int(prog[name].value_())
+
+def read_atomic(name):
+    return prog[name].counter.value_()
+
+def read_static_key(name):
+    return prog[name].key.enabled.counter.value_()
+
+def ops_state_str(state):
+    return prog['scx_ops_enable_state_str'][state].string_().decode()
+
+ops = prog['scx_ops']
+enable_state = read_atomic("scx_ops_enable_state_var")
+
+print(f'ops           : {ops.name.string_().decode()}')
+print(f'enabled       : {read_static_key("__scx_ops_enabled")}')
+print(f'switching_all : {read_int("scx_switching_all")}')
+print(f'switched_all  : {read_static_key("__scx_switched_all")}')
+print(f'enable_state  : {ops_state_str(enable_state)} ({enable_state})')
+print(f'bypass_depth  : {read_atomic("scx_ops_bypass_depth")}')
+print(f'nr_rejected   : {read_atomic("scx_nr_rejected")}')


### PR DESCRIPTION
The existing state interface in /sys/kernel/debug/sched/ext is not available if CONFIG_SCHED_DEBUG is not set. Replace it with a simpler /sys/kernel/sched_ext interface and add tools/sched_ext/scx_show_state.py to keep the same level of visibility.

This will need updates in documentation and scripts in the scx repo.