### PR TITLE
scx: Fix a couple follow ups to recent struct_ops changes

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3761,26 +3761,31 @@ static bool promote_dispatch_2nd_arg(int off, int size,
 	if (member_idx >= btf_type_vlen(t))
                 return false;
 
-        /* Get the member name of this program.  For example, the
-         * member name of the dispatch program is "dispatch".
+        /*
+	 * Get the member name of this struct_ops program, which corresponds to
+	 * a field in struct sched_ext_ops. For example, the member name of the
+	 * dispatch struct_ops program (callback) is "dispatch".
          */
 	member = &btf_type_member(t)[member_idx];
 	mname = btf_name_by_offset(btf_vmlinux, member->name_off);
 
-        /* Chkeck if it is the 2nd argument of the function pointer at
-         * "dispatch" in struct sched_ext_ops. The arguments of
-         * struct_ops operators are placed in the context one after
-         * another. And, they are 64-bits. So, the 2nd argument is at
-         * offset sizeof(__u64).
+        /*
+	 * Check if it is the second argument of the function pointer at
+	 * "dispatch" in struct sched_ext_ops. The arguments of struct_ops
+	 * operators are sequential and 64-bit, so the second argument is at
+	 * offset sizeof(__u64).
          */
         if (strcmp(mname, "dispatch") == 0 &&
             off == sizeof(__u64)) {
-                /* The value is a pointer to a type (struct
-                 * task_struct) given by a BTF ID (PTR_TO_BTF_ID). It
-                 * is tursted (PTR_TRUSTED), however, can be a NULL
-                 * (PTR_MAYBE_NULL).  The BPF program should check the
-                 * pointer to make sure it is not null before using
-                 * it, or the verifier will reject the program.
+                /*
+		 * The value is a pointer to a type (struct task_struct) given
+		 * by a BTF ID (PTR_TO_BTF_ID). It is trusted (PTR_TRUSTED),
+		 * however, can be a NULL (PTR_MAYBE_NULL). The BPF program
+		 * should check the pointer to make sure it is not NULL before
+		 * using it, or the verifier will reject the program.
+		 *
+		 * Longer term, this is something that should be addressed by
+		 * BTF, and be fully contained within the verifier.
                  */
                 info->reg_type = PTR_MAYBE_NULL | PTR_TO_BTF_ID |
                   PTR_TRUSTED;

--- a/tools/testing/selftests/scx/Makefile
+++ b/tools/testing/selftests/scx/Makefile
@@ -176,8 +176,6 @@ testcase-targets := $(addsuffix .o,$(addprefix $(SCXOBJ_DIR)/,$(auto-test-target
 $(SCXOBJ_DIR)/runner.o: runner.c | $(SCXOBJ_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-$(SCXOBJ_DIR)/maybe_null.o: $(INCLUDE_DIR)/maybe_null_fail.bpf.skel.h
-
 # Create all of the test targets object files, whose testcase objects will be
 # registered into the runner in ELF constructors.
 #
@@ -185,7 +183,10 @@ $(SCXOBJ_DIR)/maybe_null.o: $(INCLUDE_DIR)/maybe_null_fail.bpf.skel.h
 # compiling BPF object files only if one is present, as the wildcard Make
 # function doesn't support using implicit rules otherwise.
 .SECONDEXPANSION:
-$(testcase-targets): $(SCXOBJ_DIR)/%.o: %.c $(SCXOBJ_DIR)/runner.o $$(if $$(wildcard $$*.bpf.c), $(INCLUDE_DIR)/%.bpf.skel.h) | $(SCXOBJ_DIR)
+$(testcase-targets): $(SCXOBJ_DIR)/%.o: %.c $(SCXOBJ_DIR)/runner.o		\
+	$$(if $$(wildcard $$*.bpf.c), $(INCLUDE_DIR)/%.bpf.skel.h)		\
+	$$(if $$(wildcard $$*_fail.bpf.c), $(INCLUDE_DIR)/%_fail.bpf.skel.h)	\
+	| $(SCXOBJ_DIR)
 	$(eval test=$(patsubst %.o,%.c,$(notdir $@)))
 	$(CC) $(CFLAGS) -c $< -o $@ $(SCXOBJ_DIR)/runner.o
 

--- a/tools/testing/selftests/scx/maybe_null.bpf.c
+++ b/tools/testing/selftests/scx/maybe_null.bpf.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2024 Meta Platforms, Inc. and affiliates.
  */
 
 #include <scx/common.bpf.h>

--- a/tools/testing/selftests/scx/maybe_null.c
+++ b/tools/testing/selftests/scx/maybe_null.c
@@ -1,8 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
- * Copyright (c) 2023 David Vernet <dvernet@meta.com>
- * Copyright (c) 2023 Tejun Heo <tj@kernel.org>
+ * Copyright (c) 2024 Meta Platforms, Inc. and affiliates.
  */
 #include <bpf/bpf.h>
 #include <scx/common.h>

--- a/tools/testing/selftests/scx/maybe_null_fail.bpf.c
+++ b/tools/testing/selftests/scx/maybe_null_fail.bpf.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2024 Meta Platforms, Inc. and affiliates.
  */
 
 #include <scx/common.bpf.h>


### PR DESCRIPTION
- Fix a few typos and some comment formatting in ext.c
- Generalize the rule for compiling a "fail" testcase variant in seltests
- Update copyrights to 2024