### PR TITLE
Implement debug dump on abort

### DIFF
--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -18,9 +18,6 @@ struct cgroup;
 
 enum scx_consts {
 	SCX_OPS_NAME_LEN	= 128,
-	SCX_EXIT_REASON_LEN	= 128,
-	SCX_EXIT_BT_LEN		= 64,
-	SCX_EXIT_MSG_LEN	= 1024,
 
 	SCX_SLICE_DFL		= 20 * NSEC_PER_MSEC,
 	SCX_SLICE_INF		= U64_MAX,	/* infinite, implies nohz */
@@ -74,14 +71,16 @@ enum scx_exit_kind {
 struct scx_exit_info {
 	/* %SCX_EXIT_* - broad category of the exit reason */
 	enum scx_exit_kind	kind;
+
 	/* textual representation of the above */
-	char			reason[SCX_EXIT_REASON_LEN];
-	/* number of entries in the backtrace */
-	u32			bt_len;
+	const char		*reason;
+
 	/* backtrace if exiting due to an error */
-	unsigned long		bt[SCX_EXIT_BT_LEN];
-	/* extra message */
-	char			msg[SCX_EXIT_MSG_LEN];
+	unsigned long		*bt;
+	u32			bt_len;
+
+	/* informational message */
+	char			*msg;
 };
 
 /* sched_ext_ops.flags */

--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -81,6 +81,9 @@ struct scx_exit_info {
 
 	/* informational message */
 	char			*msg;
+
+	/* debug dump */
+	char			*dump;
 };
 
 /* sched_ext_ops.flags */

--- a/kernel/sched/build_policy.c
+++ b/kernel/sched/build_policy.c
@@ -25,6 +25,7 @@
 #include <linux/livepatch.h>
 #include <linux/pm.h>
 #include <linux/psi.h>
+#include <linux/seq_buf.h>
 #include <linux/seqlock_api.h>
 #include <linux/slab.h>
 #include <linux/suspend.h>

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -18,6 +18,9 @@ enum scx_internal_consts {
 	SCX_DSP_DFL_MAX_BATCH		= 32,
 	SCX_DSP_MAX_LOOPS		= 32,
 	SCX_WATCHDOG_MAX_TIMEOUT	= 30 * HZ,
+
+	SCX_EXIT_BT_LEN			= 64,
+	SCX_EXIT_MSG_LEN		= 1024,
 };
 
 enum scx_ops_enable_state {
@@ -113,7 +116,7 @@ struct static_key_false scx_has_op[SCX_OPI_END] =
 	{ [0 ... SCX_OPI_END-1] = STATIC_KEY_FALSE_INIT };
 
 static atomic_t scx_exit_kind = ATOMIC_INIT(SCX_EXIT_DONE);
-static struct scx_exit_info scx_exit_info;
+static struct scx_exit_info *scx_exit_info;
 
 static atomic_long_t scx_nr_rejected = ATOMIC_LONG_INIT(0);
 
@@ -3207,14 +3210,39 @@ static void scx_ops_bypass(bool bypass)
 	}
 }
 
+static void free_exit_info(struct scx_exit_info *ei)
+{
+	kfree(ei->msg);
+	kfree(ei->bt);
+	kfree(ei);
+}
+
+static struct scx_exit_info *alloc_exit_info(void)
+{
+	struct scx_exit_info *ei;
+
+	ei = kzalloc(sizeof(*ei), GFP_KERNEL);
+	if (!ei)
+		return NULL;
+
+	ei->bt = kcalloc(sizeof(ei->bt[0]), SCX_EXIT_BT_LEN, GFP_KERNEL);
+	ei->msg = kzalloc(SCX_EXIT_MSG_LEN, GFP_KERNEL);
+
+	if (!ei->bt || !ei->msg) {
+		free_exit_info(ei);
+		return NULL;
+	}
+
+	return ei;
+}
+
 static void scx_ops_disable_workfn(struct kthread_work *work)
 {
-	struct scx_exit_info *ei = &scx_exit_info;
+	struct scx_exit_info *ei = scx_exit_info;
 	struct scx_task_iter sti;
 	struct task_struct *p;
 	struct rhashtable_iter rht_iter;
 	struct scx_dispatch_q *dsq;
-	const char *reason;
 	int i, kind;
 
 	kind = atomic_read(&scx_exit_kind);
@@ -3229,31 +3257,29 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 		if (atomic_try_cmpxchg(&scx_exit_kind, &kind, SCX_EXIT_DONE))
 			break;
 	}
+	ei->kind = kind;
 
 	cancel_delayed_work_sync(&scx_watchdog_work);
 
-	switch (kind) {
+	switch (ei->kind) {
 	case SCX_EXIT_UNREG:
-		reason = "BPF scheduler unregistered";
+		ei->reason = "BPF scheduler unregistered";
 		break;
 	case SCX_EXIT_SYSRQ:
-		reason = "disabled by sysrq-S";
+		ei->reason = "disabled by sysrq-S";
 		break;
 	case SCX_EXIT_ERROR:
-		reason = "runtime error";
+		ei->reason = "runtime error";
 		break;
 	case SCX_EXIT_ERROR_BPF:
-		reason = "scx_bpf_error";
+		ei->reason = "scx_bpf_error";
 		break;
 	case SCX_EXIT_ERROR_STALL:
-		reason = "runnable task stall";
+		ei->reason = "runnable task stall";
 		break;
 	default:
-		reason = "<UNKNOWN>";
+		ei->reason = "<UNKNOWN>";
 	}
-
-	ei->kind = kind;
-	strlcpy(ei->reason, reason, sizeof(ei->reason));
 
 	/* guarantee forward progress by bypassing scx_ops */
 	scx_ops_bypass(true);
@@ -3264,7 +3290,7 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 		break;
 	case SCX_OPS_DISABLED:
 		pr_warn("sched_ext: ops error detected without ops (%s)\n",
-			scx_exit_info.msg);
+			scx_exit_info->msg);
 		WARN_ON_ONCE(scx_ops_set_enable_state(SCX_OPS_DISABLED) !=
 			     SCX_OPS_DISABLING);
 		goto done;
@@ -3365,6 +3391,9 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 	scx_dsp_buf = NULL;
 	scx_dsp_max_batch = 0;
 
+	free_exit_info(scx_exit_info);
+	scx_exit_info = NULL;
+
 	mutex_unlock(&scx_ops_enable_mutex);
 
 	WARN_ON_ONCE(scx_ops_set_enable_state(SCX_OPS_DISABLED) !=
@@ -3411,17 +3440,17 @@ static DEFINE_IRQ_WORK(scx_ops_error_irq_work, scx_ops_error_irq_workfn);
 __printf(2, 3) void scx_ops_error_kind(enum scx_exit_kind kind,
 				       const char *fmt, ...)
 {
-	struct scx_exit_info *ei = &scx_exit_info;
+	struct scx_exit_info *ei = scx_exit_info;
 	int none = SCX_EXIT_NONE;
 	va_list args;
 
 	if (!atomic_try_cmpxchg(&scx_exit_kind, &none, kind))
 		return;
 
-	ei->bt_len = stack_trace_save(ei->bt, ARRAY_SIZE(ei->bt), 1);
+	ei->bt_len = stack_trace_save(ei->bt, SCX_EXIT_BT_LEN, 1);
 
 	va_start(args, fmt);
-	vscnprintf(ei->msg, ARRAY_SIZE(ei->msg), fmt, args);
+	vscnprintf(ei->msg, SCX_EXIT_MSG_LEN, fmt, args);
 	va_end(args);
 
 	irq_work_queue(&scx_ops_error_irq_work);
@@ -3474,6 +3503,12 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 		goto err;
 	}
 
+	scx_exit_info = alloc_exit_info();
+	if (!scx_exit_info) {
+		ret = -ENOMEM;
+		goto err;
+	}
+
 	scx_root_kobj = kzalloc(sizeof(*scx_root_kobj), GFP_KERNEL);
 	if (!scx_root_kobj) {
 		ret = -ENOMEM;
@@ -3494,7 +3529,6 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 	WARN_ON_ONCE(scx_ops_set_enable_state(SCX_OPS_PREPPING) !=
 		     SCX_OPS_DISABLED);
 
-	memset(&scx_exit_info, 0, sizeof(scx_exit_info));
 	atomic_set(&scx_exit_kind, SCX_EXIT_NONE);
 	scx_warned_zero_slice = false;
 
@@ -3706,8 +3740,14 @@ static int scx_ops_enable(struct sched_ext_ops *ops)
 	return 0;
 
 err:
-	kfree(scx_root_kobj);
-	scx_root_kobj = NULL;
+	if (scx_root_kobj) {
+		kfree(scx_root_kobj);
+		scx_root_kobj = NULL;
+	}
+	if (scx_exit_info) {
+		free_exit_info(scx_exit_info);
+		scx_exit_info = NULL;
+	}
 	mutex_unlock(&scx_ops_enable_mutex);
 	return ret;
 

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -21,6 +21,7 @@ enum scx_internal_consts {
 
 	SCX_EXIT_BT_LEN			= 64,
 	SCX_EXIT_MSG_LEN		= 1024,
+	SCX_EXIT_DUMP_LEN		= 32768,
 };
 
 enum scx_ops_enable_state {
@@ -3220,6 +3221,7 @@ static void scx_ops_bypass(bool bypass)
 
 static void free_exit_info(struct scx_exit_info *ei)
 {
+	kfree(ei->dump);
 	kfree(ei->msg);
 	kfree(ei->bt);
 	kfree(ei);
@@ -3235,8 +3237,9 @@ static struct scx_exit_info *alloc_exit_info(void)
 
 	ei->bt = kcalloc(sizeof(ei->bt[0]), SCX_EXIT_BT_LEN, GFP_KERNEL);
 	ei->msg = kzalloc(SCX_EXIT_MSG_LEN, GFP_KERNEL);
+	ei->dump = kzalloc(SCX_EXIT_DUMP_LEN, GFP_KERNEL);
 
-	if (!ei->bt || !ei->msg) {
+	if (!ei->bt || !ei->msg || !ei->dump) {
 		free_exit_info(ei);
 		return NULL;
 	}
@@ -3437,8 +3440,106 @@ static void scx_ops_disable(enum scx_exit_kind kind)
 	schedule_scx_ops_disable_work();
 }
 
+static void scx_dump_task(struct seq_buf *s, struct task_struct *p, char marker,
+			  unsigned long now)
+{
+	static unsigned long bt[SCX_EXIT_BT_LEN];
+	char dsq_id_buf[19] = "(n/a)";
+	unsigned long ops_state = atomic_long_read(&p->scx.ops_state);
+	unsigned int bt_len;
+	size_t avail, used;
+	char *buf;
+
+	if (p->scx.dsq)
+		scnprintf(dsq_id_buf, sizeof(dsq_id_buf), "0x%llx",
+			  (unsigned long long)p->scx.dsq->id);
+
+	seq_buf_printf(s, "\n %c%c %-16s: pid=%d state/flags=%u/0x%x dsq_flags=0x%x\n",
+		       marker, task_state_to_char(p), p->comm, p->pid,
+		       scx_get_task_state(p),
+		       p->scx.flags & ~SCX_TASK_STATE_MASK,
+		       p->scx.dsq_flags);
+	seq_buf_printf(s, "%*sops_state/qseq=%lu/%lu run_at=%+ldms\n", 22, "",
+		       ops_state & SCX_OPSS_STATE_MASK,
+		       ops_state >> SCX_OPSS_QSEQ_SHIFT,
+		       jiffies_delta_msecs(p->scx.runnable_at, now));
+	seq_buf_printf(s, "%*sdsq_id=%s sticky/holding_cpu=%d/%d\n", 22, "",
+		       dsq_id_buf, p->scx.sticky_cpu, p->scx.holding_cpu);
+
+	bt_len = stack_trace_save_tsk(p, bt, SCX_EXIT_BT_LEN, 1);
+
+	avail = seq_buf_get_buf(s, &buf);
+	used = stack_trace_snprint(buf, avail, bt, bt_len, 3);
+	seq_buf_commit(s, used < avail ? used : -1);
+}
+
+static void scx_dump_state(struct scx_exit_info *ei)
+{
+	const char trunc_marker[] = "\n\n~~~~ TRUNCATED ~~~~\n";
+	unsigned long now = jiffies;
+	struct seq_buf s;
+	size_t avail, used;
+	char *buf;
+	int cpu;
+
+	seq_buf_init(&s, ei->dump, SCX_EXIT_DUMP_LEN - sizeof(trunc_marker));
+
+	seq_buf_printf(&s, "%s[%d] triggered exit kind %d:\n  %s (%s)\n\n",
+		       current->comm, current->pid, ei->kind, ei->reason, ei->msg);
+	seq_buf_printf(&s, "Backtrace:\n");
+	avail = seq_buf_get_buf(&s, &buf);
+	used = stack_trace_snprint(buf, avail, ei->bt, ei->bt_len, 1);
+	seq_buf_commit(&s, used < avail ? used : -1);
+
+	seq_buf_printf(&s, "\nRunqueue states\n");
+	seq_buf_printf(&s, "---------------\n");
+
+	for_each_possible_cpu(cpu) {
+		struct rq *rq = cpu_rq(cpu);
+		struct rq_flags rf;
+		struct task_struct *p;
+
+		rq_lock(rq, &rf);
+
+		if (list_empty(&rq->scx.runnable_list) &&
+		    rq->curr->sched_class == &idle_sched_class)
+			goto next;
+
+		seq_buf_printf(&s, "\nCPU %-4d: nr_run=%u flags=0x%x cpu_rel=%d ops_qseq=%lu pnt_seq=%lu\n",
+			       cpu, rq->scx.nr_running, rq->scx.flags,
+			       rq->scx.cpu_released, rq->scx.ops_qseq,
+			       rq->scx.pnt_seq);
+		seq_buf_printf(&s, "          curr=%s[%d] class=%ps\n",
+			       rq->curr->comm, rq->curr->pid,
+			       rq->curr->sched_class);
+		if (!cpumask_empty(rq->scx.cpus_to_kick))
+			seq_buf_printf(&s, "  cpus_to_kick   : %*pb\n",
+				       cpumask_pr_args(rq->scx.cpus_to_kick));
+		if (!cpumask_empty(rq->scx.cpus_to_preempt))
+			seq_buf_printf(&s, "  cpus_to_preempt: %*pb\n",
+				       cpumask_pr_args(rq->scx.cpus_to_preempt));
+		if (!cpumask_empty(rq->scx.cpus_to_wait))
+			seq_buf_printf(&s, "  cpus_to_wait   : %*pb\n",
+				       cpumask_pr_args(rq->scx.cpus_to_wait));
+
+		if (rq->curr->sched_class == &ext_sched_class)
+			scx_dump_task(&s, rq->curr, '*', now);
+
+		list_for_each_entry(p, &rq->scx.runnable_list, scx.runnable_node)
+			scx_dump_task(&s, p, ' ', now);
+	next:
+		rq_unlock(rq, &rf);
+	}
+
+	if (seq_buf_has_overflowed(&s)) {
+		used = strlen(seq_buf_str(&s));
+		memcpy(ei->dump + used, trunc_marker, sizeof(trunc_marker));
+	}
+}
+
 static void scx_ops_error_irq_workfn(struct irq_work *irq_work)
 {
+	scx_dump_state(scx_exit_info);
 	schedule_scx_ops_disable_work();
 }
 
@@ -3459,6 +3560,13 @@ __printf(2, 3) void scx_ops_error_kind(enum scx_exit_kind kind,
 	va_start(args, fmt);
 	vscnprintf(ei->msg, SCX_EXIT_MSG_LEN, fmt, args);
 	va_end(args);
+
+	/*
+	 * Set ei->kind and ->reason for scx_dump_state(). They'll be set again
+	 * in scx_ops_disable_workfn().
+	 */
+	ei->kind = kind;
+	ei->reason = scx_exit_reason(ei->kind);
 
 	irq_work_queue(&scx_ops_error_irq_work);
 }

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -213,6 +213,14 @@ struct scx_task_iter {
 
 #define SCX_HAS_OP(op)	static_branch_likely(&scx_has_op[SCX_OP_IDX(op)])
 
+static long jiffies_delta_msecs(unsigned long at, unsigned long now)
+{
+	if (time_after(at, now))
+		return jiffies_to_msecs(at - now);
+	else
+		return -(long)jiffies_to_msecs(now - at);
+}
+
 /* if the highest set bit is N, return a mask with bits [N+1, 31] set */
 static u32 higher_bits(u32 flags)
 {
@@ -3236,6 +3244,24 @@ static struct scx_exit_info *alloc_exit_info(void)
 	return ei;
 }
 
+static const char *scx_exit_reason(enum scx_exit_kind kind)
+{
+	switch (kind) {
+	case SCX_EXIT_UNREG:
+		return "BPF scheduler unregistered";
+	case SCX_EXIT_SYSRQ:
+		return "disabled by sysrq-S";
+	case SCX_EXIT_ERROR:
+		return "runtime error";
+	case SCX_EXIT_ERROR_BPF:
+		return "scx_bpf_error";
+	case SCX_EXIT_ERROR_STALL:
+		return "runnable task stall";
+	default:
+		return "<UNKNOWN>";
+	}
+}
+
 static void scx_ops_disable_workfn(struct kthread_work *work)
 {
 	struct scx_exit_info *ei = scx_exit_info;
@@ -3258,28 +3284,9 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 			break;
 	}
 	ei->kind = kind;
+	ei->reason = scx_exit_reason(ei->kind);
 
 	cancel_delayed_work_sync(&scx_watchdog_work);
-
-	switch (ei->kind) {
-	case SCX_EXIT_UNREG:
-		ei->reason = "BPF scheduler unregistered";
-		break;
-	case SCX_EXIT_SYSRQ:
-		ei->reason = "disabled by sysrq-S";
-		break;
-	case SCX_EXIT_ERROR:
-		ei->reason = "runtime error";
-		break;
-	case SCX_EXIT_ERROR_BPF:
-		ei->reason = "scx_bpf_error";
-		break;
-	case SCX_EXIT_ERROR_STALL:
-		ei->reason = "runnable task stall";
-		break;
-	default:
-		ei->reason = "<UNKNOWN>";
-	}
 
 	/* guarantee forward progress by bypassing scx_ops */
 	scx_ops_bypass(true);
@@ -4115,8 +4122,8 @@ void print_scx_info(const char *log_lvl, struct task_struct *p)
 
 	if (!copy_from_kernel_nofault(&runnable_at, &p->scx.runnable_at,
 				      sizeof(runnable_at)))
-		scnprintf(runnable_at_buf, sizeof(runnable_at_buf), "%+lldms",
-			  (s64)(runnable_at - jiffies) * (HZ / MSEC_PER_SEC));
+		scnprintf(runnable_at_buf, sizeof(runnable_at_buf), "%+ldms",
+			  jiffies_delta_msecs(runnable_at, jiffies));
 
 	/* print everything onto one line to conserve console space */
 	printk("%sSched_ext: %s (%s%s), task: runnable_at=%s",


### PR DESCRIPTION
When a scx scheduler aborts, it can be difficult to find out what happened because all the scheduling states are lost as the system is reverted back to the default scheduler. Capture and dump the releavant states to aid debugging. In the future, it'd be useful to add `ops.dump()` and `ops.dump_task()` so that BPF scheduler can dump states specific to the BPF scheduler.

```
root@test ~# os/work/tools/sched_ext/build/bin/scx_qmap -t 500
enq=5, dsp=0, delta=5, reenq=0, deq=0, core=0
enq=451, dsp=445, delta=6, reenq=0, deq=0, core=0
enq=871, dsp=868, delta=3, reenq=0, deq=0, core=0
enq=1263, dsp=1259, delta=4, reenq=8, deq=0, core=0
enq=1595, dsp=1593, delta=2, reenq=8, deq=0, core=0
enq=1870, dsp=1869, delta=1, reenq=8, deq=0, core=0
enq=1940, dsp=1939, delta=1, reenq=8, deq=0, core=0
enq=1974, dsp=1974, delta=0, reenq=15, deq=0, core=0

DEBUG DUMP
================================================================================

kworker/u16:4[173] triggered exit kind 1026:
  runnable task stall (yes[1632] failed to run for 5.314s)

Backtrace:
  scx_watchdog_workfn+0x143/0x1d0
  process_scheduled_works+0x245/0x4e0
  worker_thread+0x270/0x360
  kthread+0xeb/0x110
  ret_from_fork+0x36/0x40
  ret_from_fork_asm+0x11/0x20

Runqueue states
---------------

CPU 0   : nr_run=1 flags=0x0 cpu_rel=0 ops_qseq=435 pnt_seq=440
          curr=stress[1643] class=ext_sched_class

 *R stress          : pid=1643 state/flags=3/0x5 dsq_flags=0x0
                      ops_state/qseq=0/0 run_at=-4ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1

CPU 1   : nr_run=2 flags=0x0 cpu_rel=0 ops_qseq=398 pnt_seq=400
          curr=yes[1636] class=ext_sched_class

 *R yes             : pid=1636 state/flags=3/0x5 dsq_flags=0x0
                      ops_state/qseq=0/0 run_at=-20ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1

  R yes             : pid=1630 state/flags=3/0x1 dsq_flags=0x0
                      ops_state/qseq=2/196 run_at=-4097ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1
    irqentry_exit+0x54/0x80
    sysvec_apic_timer_interrupt+0x44/0x80
    asm_sysvec_apic_timer_interrupt+0x1b/0x20
    __fdget_pos+0x4d/0xc0
    ksys_write+0x21/0xc0
    __x64_sys_write+0x1b/0x20
    do_syscall_64+0x40/0xe0
    entry_SYSCALL_64_after_hwframe+0x46/0x4e

CPU 2   : nr_run=1 flags=0x0 cpu_rel=0 ops_qseq=411 pnt_seq=415
          curr=stress[1646] class=ext_sched_class

 *R stress          : pid=1646 state/flags=3/0x5 dsq_flags=0x0
                      ops_state/qseq=0/0 run_at=-3ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1

CPU 3   : nr_run=2 flags=0x0 cpu_rel=0 ops_qseq=383 pnt_seq=382
          curr=swapper/3[0] class=idle_sched_class

  R yes             : pid=1632 state/flags=3/0x1 dsq_flags=0x0
                      ops_state/qseq=2/118 run_at=-5314ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1
    irqentry_exit+0x54/0x80
    sysvec_apic_timer_interrupt+0x44/0x80
    asm_sysvec_apic_timer_interrupt+0x1b/0x20
    syscall_enter_from_user_mode+0x39/0x1b0
    do_syscall_64+0x21/0xe0
    entry_SYSCALL_64_after_hwframe+0x46/0x4e

  R stress          : pid=1648 state/flags=3/0x1 dsq_flags=0x0
                      ops_state/qseq=2/382 run_at=-5ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1
    exit_to_user_mode_prepare+0x96/0x120
    irqentry_exit_to_user_mode+0x9/0x40
    irqentry_exit+0x31/0x80
    sysvec_apic_timer_interrupt+0x44/0x80
    asm_sysvec_apic_timer_interrupt+0x1b/0x20

CPU 4   : nr_run=2 flags=0x0 cpu_rel=0 ops_qseq=412 pnt_seq=415
          curr=stress[1644] class=ext_sched_class

 *R stress          : pid=1644 state/flags=3/0x5 dsq_flags=0x0
                      ops_state/qseq=0/0 run_at=-5ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1

  R stress          : pid=1642 state/flags=3/0x1 dsq_flags=0x0
                      ops_state/qseq=2/273 run_at=-2775ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1
    exit_to_user_mode_prepare+0x96/0x120
    irqentry_exit_to_user_mode+0x9/0x40
    irqentry_exit+0x31/0x80
    sysvec_apic_timer_interrupt+0x44/0x80
    asm_sysvec_apic_timer_interrupt+0x1b/0x20

CPU 5   : nr_run=1 flags=0x0 cpu_rel=0 ops_qseq=383 pnt_seq=387
          curr=stress[1649] class=ext_sched_class

 *R stress          : pid=1649 state/flags=3/0x5 dsq_flags=0x0
                      ops_state/qseq=0/0 run_at=-6ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1

CPU 6   : nr_run=2 flags=0x0 cpu_rel=0 ops_qseq=391 pnt_seq=390
          curr=stress[1645] class=ext_sched_class

 *R stress          : pid=1645 state/flags=3/0x5 dsq_flags=0x0
                      ops_state/qseq=0/0 run_at=-18ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1

  R stress          : pid=1647 state/flags=3/0x1 dsq_flags=0x0
                      ops_state/qseq=2/71 run_at=-6470ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1
    exit_to_user_mode_prepare+0x96/0x120
    irqentry_exit_to_user_mode+0x9/0x40
    irqentry_exit+0x31/0x80
    sysvec_apic_timer_interrupt+0x44/0x80
    asm_sysvec_apic_timer_interrupt+0x1b/0x20

CPU 7   : nr_run=2 flags=0x0 cpu_rel=0 ops_qseq=357 pnt_seq=373
          curr=kworker/u16:4[173] class=ext_sched_class

 *R kworker/u16:4   : pid=173 state/flags=3/0xd dsq_flags=0x0
                      ops_state/qseq=0/0 run_at=+0ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1
    scx_ops_error_irq_workfn+0x312/0x400
    irq_work_run_list+0x7d/0xc0
    irq_work_run+0x18/0x30
    __sysvec_irq_work+0x38/0x100
    sysvec_irq_work+0x69/0x80
    asm_sysvec_irq_work+0x1b/0x20
    scx_watchdog_workfn+0x168/0x1d0
    process_scheduled_works+0x245/0x4e0
    worker_thread+0x270/0x360
    kthread+0xeb/0x110
    ret_from_fork+0x36/0x40
    ret_from_fork_asm+0x11/0x20

  R yes             : pid=1634 state/flags=3/0x1 dsq_flags=0x0
                      ops_state/qseq=2/343 run_at=-1473ms
                      dsq_id=(n/a) sticky/holding_cpu=-1/-1
    irqentry_exit+0x54/0x80
    sysvec_apic_timer_interrupt+0x44/0x80
    asm_sysvec_apic_timer_interrupt+0x1b/0x20
    syscall_enter_from_user_mode+0x39/0x1b0
    do_syscall_64+0x21/0xe0
    entry_SYSCALL_64_after_hwframe+0x46/0x4e

================================================================================

EXIT: runnable task stall (yes[1632] failed to run for 5.314s)
```