### PR TITLE
scx: Implement scx_bpf_dispatch_cancel()

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -4535,6 +4535,25 @@ u32 scx_bpf_dispatch_nr_slots(void)
 }
 
 /**
+ * scx_bpf_dispatch_cancel - Cancel the latest dispatch
+ *
+ * Cancel the latest dispatch. Can be called multiple times to cancel further
+ * dispatches. Can only be called from ops.dispatch().
+ */
+void scx_bpf_dispatch_cancel(void)
+{
+	struct scx_dsp_ctx *dspc = this_cpu_ptr(&scx_dsp_ctx);
+
+	if (!scx_kf_allowed(SCX_KF_DISPATCH))
+		return;
+
+	if (dspc->buf_cursor > 0)
+		dspc->buf_cursor--;
+	else
+		scx_ops_error("dispatch buffer underflow");
+}
+
+/**
  * scx_bpf_consume - Transfer a task from a DSQ to the current CPU's local DSQ
  * @dsq_id: DSQ to consume
  *
@@ -4581,6 +4600,7 @@ bool scx_bpf_consume(u64 dsq_id)
 
 BTF_SET8_START(scx_kfunc_ids_dispatch)
 BTF_ID_FLAGS(func, scx_bpf_dispatch_nr_slots)
+BTF_ID_FLAGS(func, scx_bpf_dispatch_cancel)
 BTF_ID_FLAGS(func, scx_bpf_consume)
 BTF_SET8_END(scx_kfunc_ids_dispatch)
 


### PR DESCRIPTION
This can be used to implement interlocking against dequeue. e.g, Let's say there is one dsq per CPU and the scheduler can stall if a task is dispatched to a dsq which doesn't intersect with p->cpus_ptr. In the dispatch path, if you do the following:

	if (bpf_cpumask_test_cpu(target_cpu, p->cpus_ptr))
		scx_bpf_dispatch(p, target_dsq, slice, 0);

The task can still end up in the wrong dsq because the cpumask can change between bpf_cpumask_test_cpu() and scx_bpf_dispatch(). However,

	scx_bpf_dispatch(p, target_dsq, slice, 0);
	if (!bpf_cpumask_test_cpu(target_cpu, p->cpus_ptr))
		scx_bpf_dispatch_cancel();

eliminates the race window - either the set_cpumask path sees the task dispatched or the dispatch path sees the updated cpumask. In both cases, the dispatch gets canceled as it should.

Note that in schedules which don't implement .dequeue(), depending on the implementation, there can be multiple enqueued instances of the same task. However, as long as the scheduler guarantees that there is at least one dispatch attempt on the task since the last enqueueing and that dispatch attempt interlocks against the dequeue path as above, it's guaranteed to not act upon stale information or miss dispatching an enqueued task.


Cc: Andrea Righi <andrea.righi@canonical.com>