### PR TITLE
scx: Actually allocate rq->scx.cpus_to_kick_if_idle

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -4382,6 +4382,7 @@ void __init init_sched_ext_class(void)
 		INIT_LIST_HEAD(&rq->scx.runnable_list);
 
 		BUG_ON(!zalloc_cpumask_var(&rq->scx.cpus_to_kick, GFP_KERNEL));
+		BUG_ON(!zalloc_cpumask_var(&rq->scx.cpus_to_kick_if_idle, GFP_KERNEL));
 		BUG_ON(!zalloc_cpumask_var(&rq->scx.cpus_to_preempt, GFP_KERNEL));
 		BUG_ON(!zalloc_cpumask_var(&rq->scx.cpus_to_wait, GFP_KERNEL));
 		init_irq_work(&rq->scx.kick_cpus_irq_work, kick_cpus_irq_workfn);


### PR DESCRIPTION
To avoid crashing the kernel when CONFIG_CPUMASK_OFFSTACK is set.