### PR TITLE
scx: Don't wait for a work item before scheduling is restored in scx_…

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3309,8 +3309,6 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 	ei->kind = kind;
 	ei->reason = scx_exit_reason(ei->kind);
 
-	cancel_delayed_work_sync(&scx_watchdog_work);
-
 	/* guarantee forward progress by bypassing scx_ops */
 	scx_ops_bypass(true);
 
@@ -3396,6 +3394,7 @@ static void scx_ops_disable_workfn(struct kthread_work *work)
 	if (scx_ops.exit)
 		SCX_CALL_OP(SCX_KF_UNLOCKED, exit, ei);
 
+	cancel_delayed_work_sync(&scx_watchdog_work);
 	kobject_del(scx_root_kobj);
 	scx_root_kobj = NULL;
 


### PR DESCRIPTION
…ops_disable_workfn()

When scx_ops_disable_workfn() invoked to disable a BPF scheduler, it cannot depend on the scheduler working and thus can't depend on !RT tasks making forward progress, so it performs a series of non-blocking operations to restore forward progress guarantee and then kicks out the BPF scheduler.

Watchdog code added cancel_delayed_work_sync() in scx_ops_disable_workfn() before forward progress guarantee is restored. cancel_delayed_work_sync() implies flush_work() if the target work item is already executing and that work item may not be able to run due to malfunctioning scheduling, making the system stuck and unrecoverable.

There's no need to shutdown the watchdog timer early. Move cancel_delayed_work_sync() to later in the disable process where all the critical operaitons are complete and the kernel default scheduling is restored.