### PR TITLE
scx: Ignore WF_EXEC

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -2154,6 +2154,19 @@ __bpf_kfunc_end_defs();
 
 static int select_task_rq_scx(struct task_struct *p, int prev_cpu, int wake_flags)
 {
+	/*
+	 * sched_exec() calls with %WF_EXEC when @p is about to exec(2) as it
+	 * can be a good migration opportunity with low cache and memory
+	 * footprint. Returning a CPU different than @prev_cpu triggers
+	 * immediate rq migration. However, for SCX, as the current rq
+	 * association doesn't dictate where the task is going to run, this
+	 * doesn't fit well. If necessary, we can later add a dedicated method
+	 * which can decide to preempt self to force it through the regular
+	 * scheduling path.
+	 */
+	if (unlikely(wake_flags & WF_EXEC))
+		return prev_cpu;
+
 	if (SCX_HAS_OP(select_cpu)) {
 		s32 cpu;
 		struct task_struct **ddsp_taskp;
@@ -4433,8 +4446,8 @@ void __init init_sched_ext_class(void)
 	 * definitions so that BPF scheduler implementations can use them
 	 * through the generated vmlinux.h.
 	 */
-	WRITE_ONCE(v, SCX_WAKE_EXEC | SCX_ENQ_WAKEUP | SCX_DEQ_SLEEP |
-		   SCX_TG_ONLINE | SCX_KICK_PREEMPT);
+	WRITE_ONCE(v, SCX_ENQ_WAKEUP | SCX_DEQ_SLEEP | SCX_TG_ONLINE |
+		   SCX_KICK_PREEMPT);
 
 	BUG_ON(rhashtable_init(&dsq_hash, &dsq_hash_params));
 	init_dsq(&scx_dsq_global, SCX_DSQ_GLOBAL);

--- a/kernel/sched/ext.h
+++ b/kernel/sched/ext.h
@@ -8,7 +8,6 @@
  */
 enum scx_wake_flags {
 	/* expose select WF_* flags as enums */
-	SCX_WAKE_EXEC		= WF_EXEC,
 	SCX_WAKE_FORK		= WF_FORK,
 	SCX_WAKE_TTWU		= WF_TTWU,
 	SCX_WAKE_SYNC		= WF_SYNC,


### PR DESCRIPTION
sched_exec() calls select_task_rq() and then do a rq migration if the returned cpu is different from current. This calls ops.select_cpu() outside the normal enqueue path confusing the direct dispatch mechanism - e.g. rq->scx.ddsp_dsq_id can be asserted when it shouldn't be.

I tried to make ops.select_cpu() work in this path but the mechanism doesn't make whole lot of sense for scx and it makes the semantics around ops.select_cpu() unnecessarily complicated for rare corner cases. If we want this behavior, I think the right thing to do is adding a separate method which can preempt self to trigger the normal scheduling path for the task.