### PR TITLE
scx: Make exit debug dump buffer resizable

### DIFF
--- a/include/linux/sched/ext.h
+++ b/include/linux/sched/ext.h
@@ -599,6 +599,12 @@ struct sched_ext_ops {
 	u32 timeout_ms;
 
 	/**
+	 * exit_dump_len - scx_exit_info.dump buffer length. If 0, the default
+	 * value of 32768 is used.
+	 */
+	u32 exit_dump_len;
+
+	/**
 	 * name - BPF scheduler's name
 	 *
 	 * Must be a non-zero valid BPF object name including only isalnum(),

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -4086,6 +4086,9 @@ static int bpf_scx_init_member(const struct btf_type *t,
 			return -E2BIG;
 		ops->timeout_ms = *(u32 *)(udata + moff);
 		return 1;
+	case offsetof(struct sched_ext_ops, exit_dump_len):
+		ops->exit_dump_len = *(u32 *)(udata + moff);
+		return 1;
 	}
 
 	return 0;

--- a/tools/sched_ext/include/scx/common.h
+++ b/tools/sched_ext/include/scx/common.h
@@ -17,8 +17,6 @@
 #include <stdint.h>
 #include <errno.h>
 
-#include "user_exit_info.h"
-
 typedef uint8_t u8;
 typedef uint16_t u16;
 typedef uint32_t u32;
@@ -67,6 +65,7 @@ typedef int64_t s64;
 			bpf_map__initial_value(skel->maps.elfsec##_##arr, &__sz); \
 	} while (0)
 
+#include "user_exit_info.h"
 #include "compat.h"
 
 #endif	/* __SCHED_EXT_COMMON_H */

--- a/tools/sched_ext/include/scx/compat.bpf.h
+++ b/tools/sched_ext/include/scx/compat.bpf.h
@@ -76,7 +76,8 @@ struct sched_ext_ops___no_exit_dump_len {
 	char name[128];
 };
 
-#define DEFINE_SCX_OPS(__name, ...)						\
+/* define sched_ext_ops, see compat.h::SCX_OPS_LOAD/ATTACH() */
+#define SCX_OPS_DEFINE(__name, ...)						\
 	SEC(".struct_ops.link")							\
 	struct sched_ext_ops __name = {						\
 		__VA_ARGS__,							\

--- a/tools/sched_ext/include/scx/compat.bpf.h
+++ b/tools/sched_ext/include/scx/compat.bpf.h
@@ -35,3 +35,43 @@ static inline void __COMPAT_scx_bpf_switch_all(void)
 }
 
 #endif
+
+/*
+ * sched_ext_ops.exit_dump_len is a recent addition. Use the following
+ * definition to support older kernels. See scx_qmap for usage example.
+ */
+struct sched_ext_ops___no_exit_dump_len {
+	s32 (*select_cpu)(struct task_struct *, s32, u64);
+	void (*enqueue)(struct task_struct *, u64);
+	void (*dequeue)(struct task_struct *, u64);
+	void (*dispatch)(s32, struct task_struct *);
+	void (*runnable)(struct task_struct *, u64);
+	void (*running)(struct task_struct *);
+	void (*stopping)(struct task_struct *, bool);
+	void (*quiescent)(struct task_struct *, u64);
+	bool (*yield)(struct task_struct *, struct task_struct *);
+	bool (*core_sched_before)(struct task_struct *, struct task_struct *);
+	void (*set_weight)(struct task_struct *, u32);
+	void (*set_cpumask)(struct task_struct *, const struct cpumask *);
+	void (*update_idle)(s32, bool);
+	void (*cpu_acquire)(s32, struct scx_cpu_acquire_args *);
+	void (*cpu_release)(s32, struct scx_cpu_release_args *);
+	s32 (*init_task)(struct task_struct *, struct scx_init_task_args *);
+	void (*exit_task)(struct task_struct *, struct scx_exit_task_args *);
+	void (*enable)(struct task_struct *);
+	void (*disable)(struct task_struct *);
+	s32 (*cgroup_init)(struct cgroup *, struct scx_cgroup_init_args *);
+	void (*cgroup_exit)(struct cgroup *);
+	s32 (*cgroup_prep_move)(struct task_struct *, struct cgroup *, struct cgroup *);
+	void (*cgroup_move)(struct task_struct *, struct cgroup *, struct cgroup *);
+	void (*cgroup_cancel_move)(struct task_struct *, struct cgroup *, struct cgroup *);
+	void (*cgroup_set_weight)(struct cgroup *, u32);
+	void (*cpu_online)(s32);
+	void (*cpu_offline)(s32);
+	s32 (*init)();
+	void (*exit)(struct scx_exit_info *);
+	u32 dispatch_max_batch;
+	u64 flags;
+	u32 timeout_ms;
+	char name[128];
+};

--- a/tools/sched_ext/include/scx/compat.bpf.h
+++ b/tools/sched_ext/include/scx/compat.bpf.h
@@ -75,3 +75,13 @@ struct sched_ext_ops___no_exit_dump_len {
 	u32 timeout_ms;
 	char name[128];
 };
+
+#define DEFINE_SCX_OPS(__name, ...)						\
+	SEC(".struct_ops.link")							\
+	struct sched_ext_ops __name = {						\
+		__VA_ARGS__,							\
+	};									\
+	SEC(".struct_ops.link")							\
+	struct sched_ext_ops___no_exit_dump_len __name##___no_exit_dump_len = {	\
+		__VA_ARGS__							\
+	};									\

--- a/tools/sched_ext/include/scx/compat.h
+++ b/tools/sched_ext/include/scx/compat.h
@@ -116,7 +116,8 @@ static inline bool __COMPAT_struct_has_field(const char *type, const char *field
  *   it, the value is ignored and a warning is triggered if the value is
  *   requested to be non-zero.
  */
-#define SCX_OPS_LOAD(__skel, __ops_name, __scx_name) ({				\
+#define SCX_OPS_LOAD(__skel, __ops_name, __scx_name, __uei_name) ({		\
+	UEI_SET_SIZE(__skel, __ops_name, __uei_name);				\
 	if (__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len")) {	\
 		bpf_map__set_autocreate((__skel)->maps.__ops_name, true);	\
 		bpf_map__set_autocreate((__skel)->maps.__ops_name##___no_exit_dump_len, false); \

--- a/tools/sched_ext/include/scx/compat.h
+++ b/tools/sched_ext/include/scx/compat.h
@@ -106,7 +106,37 @@ static inline bool __COMPAT_struct_has_field(const char *type, const char *field
 #define __COMPAT_SCX_OPS_SWITCH_PARTIAL						\
 	__COMPAT_ENUM_OR_ZERO("scx_ops_flags", "SCX_OPS_SWITCH_PARTIAL")
 
-#define __COMPAT_KERNEL_HAS_OPS_EXIT_DUMP_LEN					\
-	__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len")
+/*
+ * struct sched_ext_ops can change over time. If compat.bpf.h::SCX_OPS_DEFINE()
+ * is used to define ops and compat.h::SCX_OPS_LOAD/ATTACH() are used to load
+ * and attach it, backward compatibility is automatically maintained where
+ * reasonable.
+ *
+ * - sched_ext_ops.exit_dump_len was added later. On kernels which don't support
+ *   it, the value is ignored and a warning is triggered if the value is
+ *   requested to be non-zero.
+ */
+#define SCX_OPS_LOAD(__skel, __ops_name, __scx_name) ({				\
+	if (__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len")) {	\
+		bpf_map__set_autocreate((__skel)->maps.__ops_name, true);	\
+		bpf_map__set_autocreate((__skel)->maps.__ops_name##___no_exit_dump_len, false); \
+	} else {								\
+		if ((__skel)->struct_ops.__ops_name->exit_dump_len)		\
+			fprintf(stderr, "WARNING: kernel doesn't support setting exit dump len\n"); \
+		bpf_map__set_autocreate((__skel)->maps.__ops_name, false);	\
+		bpf_map__set_autocreate((__skel)->maps.__ops_name##___no_exit_dump_len, true); \
+	}									\
+	SCX_BUG_ON(__scx_name##__load((__skel)), "Failed to load skel");	\
+})
+
+#define SCX_OPS_ATTACH(__skel, __ops_name) ({					\
+	struct bpf_link *__link;						\
+	if (__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len"))	\
+		__link = bpf_map__attach_struct_ops((__skel)->maps.__ops_name);	\
+	else									\
+		__link = bpf_map__attach_struct_ops((__skel)->maps.__ops_name##___no_exit_dump_len); \
+	SCX_BUG_ON(!__link, "Failed to attach struct_ops");			\
+	__link;									\
+})
 
 #endif	/* __SCX_COMPAT_H */

--- a/tools/sched_ext/scx_central.bpf.c
+++ b/tools/sched_ext/scx_central.bpf.c
@@ -64,7 +64,7 @@ u64 nr_total, nr_locals, nr_queued, nr_lost_pids;
 u64 nr_timers, nr_dispatches, nr_mismatches, nr_retries;
 u64 nr_overflows;
 
-struct user_exit_info uei;
+UEI_DEFINE(uei);
 
 struct {
 	__uint(type, BPF_MAP_TYPE_QUEUE);
@@ -340,7 +340,7 @@ int BPF_STRUCT_OPS_SLEEPABLE(central_init)
 
 void BPF_STRUCT_OPS(central_exit, struct scx_exit_info *ei)
 {
-	uei_record(&uei, ei);
+	UEI_RECORD(uei, ei);
 }
 
 SCX_OPS_DEFINE(central_ops,

--- a/tools/sched_ext/scx_central.bpf.c
+++ b/tools/sched_ext/scx_central.bpf.c
@@ -343,21 +343,19 @@ void BPF_STRUCT_OPS(central_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops.link")
-struct sched_ext_ops central_ops = {
-	/*
-	 * We are offloading all scheduling decisions to the central CPU and
-	 * thus being the last task on a given CPU doesn't mean anything
-	 * special. Enqueue the last tasks like any other tasks.
-	 */
-	.flags			= SCX_OPS_ENQ_LAST,
+SCX_OPS_DEFINE(central_ops,
+	       /*
+		* We are offloading all scheduling decisions to the central CPU
+		* and thus being the last task on a given CPU doesn't mean
+		* anything special. Enqueue the last tasks like any other tasks.
+		*/
+	       .flags			= SCX_OPS_ENQ_LAST,
 
-	.select_cpu		= (void *)central_select_cpu,
-	.enqueue		= (void *)central_enqueue,
-	.dispatch		= (void *)central_dispatch,
-	.running		= (void *)central_running,
-	.stopping		= (void *)central_stopping,
-	.init			= (void *)central_init,
-	.exit			= (void *)central_exit,
-	.name			= "central",
-};
+	       .select_cpu		= (void *)central_select_cpu,
+	       .enqueue			= (void *)central_enqueue,
+	       .dispatch		= (void *)central_dispatch,
+	       .running			= (void *)central_running,
+	       .stopping		= (void *)central_stopping,
+	       .init			= (void *)central_init,
+	       .exit			= (void *)central_exit,
+	       .name			= "central");

--- a/tools/sched_ext/scx_central.c
+++ b/tools/sched_ext/scx_central.c
@@ -20,7 +20,7 @@ const char help_fmt[] =
 "\n"
 "See the top-level comment in .bpf.c for more details.\n"
 "\n"
-"Usage: %s [-s SLICE_US] [-c CPU] [-p]\n"
+"Usage: %s [-s SLICE_US] [-c CPU]\n"
 "\n"
 "  -s SLICE_US   Override slice duration\n"
 "  -c CPU        Override the central CPU (default: 0)\n"

--- a/tools/sched_ext/scx_central.c
+++ b/tools/sched_ext/scx_central.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
 	RESIZE_ARRAY(data, cpu_gimme_task, skel->rodata->nr_cpu_ids);
 	RESIZE_ARRAY(data, cpu_started_at, skel->rodata->nr_cpu_ids);
 
-	SCX_OPS_LOAD(skel, central_ops, scx_central);
+	SCX_OPS_LOAD(skel, central_ops, scx_central, uei);
 
 	/*
 	 * Affinitize the loading thread to the central CPU, as:
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
 	if (!skel->data->timer_pinned)
 		printf("WARNING : BPF_F_TIMER_CPU_PIN not available, timer not pinned to central\n");
 
-	while (!exit_req && !uei_exited(&skel->bss->uei)) {
+	while (!exit_req && !UEI_EXITED(skel, uei)) {
 		printf("[SEQ %llu]\n", seq++);
 		printf("total   :%10" PRIu64 "    local:%10" PRIu64 "   queued:%10" PRIu64 "  lost:%10" PRIu64 "\n",
 		       skel->bss->nr_total,
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
 	}
 
 	bpf_link__destroy(link);
-	uei_print(&skel->bss->uei);
+	UEI_REPORT(skel, uei);
 	scx_central__destroy(skel);
 	return 0;
 }

--- a/tools/sched_ext/scx_central.c
+++ b/tools/sched_ext/scx_central.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
 	RESIZE_ARRAY(data, cpu_gimme_task, skel->rodata->nr_cpu_ids);
 	RESIZE_ARRAY(data, cpu_started_at, skel->rodata->nr_cpu_ids);
 
-	SCX_BUG_ON(scx_central__load(skel), "Failed to load skel");
+	SCX_OPS_LOAD(skel, central_ops, scx_central);
 
 	/*
 	 * Affinitize the loading thread to the central CPU, as:
@@ -92,8 +92,7 @@ int main(int argc, char **argv)
 		   skel->rodata->central_cpu, skel->rodata->nr_cpu_ids - 1);
 	CPU_FREE(cpuset);
 
-	link = bpf_map__attach_struct_ops(skel->maps.central_ops);
-	SCX_BUG_ON(!link, "Failed to attach struct_ops");
+	link = SCX_OPS_ATTACH(skel, central_ops);
 
 	if (!skel->data->timer_pinned)
 		printf("WARNING : BPF_F_TIMER_CPU_PIN not available, timer not pinned to central\n");

--- a/tools/sched_ext/scx_flatcg.bpf.c
+++ b/tools/sched_ext/scx_flatcg.bpf.c
@@ -58,7 +58,7 @@ const volatile u64 cgrp_slice_ns = SCX_SLICE_DFL;
 const volatile bool fifo_sched;
 
 u64 cvtime_now;
-struct user_exit_info uei;
+UEI_DEFINE(uei);
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
@@ -928,7 +928,7 @@ void BPF_STRUCT_OPS(fcg_cgroup_move, struct task_struct *p,
 
 void BPF_STRUCT_OPS(fcg_exit, struct scx_exit_info *ei)
 {
-	uei_record(&uei, ei);
+	UEI_RECORD(uei, ei);
 }
 
 SCX_OPS_DEFINE(flatcg_ops,

--- a/tools/sched_ext/scx_flatcg.bpf.c
+++ b/tools/sched_ext/scx_flatcg.bpf.c
@@ -931,21 +931,19 @@ void BPF_STRUCT_OPS(fcg_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops.link")
-struct sched_ext_ops flatcg_ops = {
-	.select_cpu		= (void *)fcg_select_cpu,
-	.enqueue		= (void *)fcg_enqueue,
-	.dispatch		= (void *)fcg_dispatch,
-	.runnable		= (void *)fcg_runnable,
-	.running		= (void *)fcg_running,
-	.stopping		= (void *)fcg_stopping,
-	.quiescent		= (void *)fcg_quiescent,
-	.init_task		= (void *)fcg_init_task,
-	.cgroup_set_weight	= (void *)fcg_cgroup_set_weight,
-	.cgroup_init		= (void *)fcg_cgroup_init,
-	.cgroup_exit		= (void *)fcg_cgroup_exit,
-	.cgroup_move		= (void *)fcg_cgroup_move,
-	.exit			= (void *)fcg_exit,
-	.flags			= SCX_OPS_CGROUP_KNOB_WEIGHT | SCX_OPS_ENQ_EXITING,
-	.name			= "flatcg",
-};
+SCX_OPS_DEFINE(flatcg_ops,
+	       .select_cpu		= (void *)fcg_select_cpu,
+	       .enqueue			= (void *)fcg_enqueue,
+	       .dispatch		= (void *)fcg_dispatch,
+	       .runnable		= (void *)fcg_runnable,
+	       .running			= (void *)fcg_running,
+	       .stopping		= (void *)fcg_stopping,
+	       .quiescent		= (void *)fcg_quiescent,
+	       .init_task		= (void *)fcg_init_task,
+	       .cgroup_set_weight	= (void *)fcg_cgroup_set_weight,
+	       .cgroup_init		= (void *)fcg_cgroup_init,
+	       .cgroup_exit		= (void *)fcg_cgroup_exit,
+	       .cgroup_move		= (void *)fcg_cgroup_move,
+	       .exit			= (void *)fcg_exit,
+	       .flags			= SCX_OPS_CGROUP_KNOB_WEIGHT | SCX_OPS_ENQ_EXITING,
+	       .name			= "flatcg");

--- a/tools/sched_ext/scx_flatcg.c
+++ b/tools/sched_ext/scx_flatcg.c
@@ -26,7 +26,7 @@ const char help_fmt[] =
 "\n"
 "See the top-level comment in .bpf.c for more details.\n"
 "\n"
-"Usage: %s [-s SLICE_US] [-i INTERVAL] [-f] [-p]\n"
+"Usage: %s [-s SLICE_US] [-i INTERVAL] [-f]\n"
 "\n"
 "  -s SLICE_US   Override slice duration\n"
 "  -i INTERVAL   Report interval\n"

--- a/tools/sched_ext/scx_flatcg.c
+++ b/tools/sched_ext/scx_flatcg.c
@@ -161,10 +161,10 @@ int main(int argc, char **argv)
 	       (double)intv_ts.tv_sec + (double)intv_ts.tv_nsec / 1000000000.0,
 	       dump_cgrps);
 
-	SCX_OPS_LOAD(skel, flatcg_ops, scx_flatcg);
+	SCX_OPS_LOAD(skel, flatcg_ops, scx_flatcg, uei);
 	link = SCX_OPS_ATTACH(skel, flatcg_ops);
 
-	while (!exit_req && !uei_exited(&skel->bss->uei)) {
+	while (!exit_req && !UEI_EXITED(skel, uei)) {
 		__u64 acc_stats[FCG_NR_STATS];
 		__u64 stats[FCG_NR_STATS];
 		float cpu_util;
@@ -213,7 +213,7 @@ int main(int argc, char **argv)
 	}
 
 	bpf_link__destroy(link);
-	uei_print(&skel->bss->uei);
+	UEI_REPORT(skel, uei);
 	scx_flatcg__destroy(skel);
 	return 0;
 }

--- a/tools/sched_ext/scx_flatcg.c
+++ b/tools/sched_ext/scx_flatcg.c
@@ -161,10 +161,8 @@ int main(int argc, char **argv)
 	       (double)intv_ts.tv_sec + (double)intv_ts.tv_nsec / 1000000000.0,
 	       dump_cgrps);
 
-	SCX_BUG_ON(scx_flatcg__load(skel), "Failed to load skel");
-
-	link = bpf_map__attach_struct_ops(skel->maps.flatcg_ops);
-	SCX_BUG_ON(!link, "Failed to attach struct_ops");
+	SCX_OPS_LOAD(skel, flatcg_ops, scx_flatcg);
+	link = SCX_OPS_ATTACH(skel, flatcg_ops);
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {
 		__u64 acc_stats[FCG_NR_STATS];

--- a/tools/sched_ext/scx_qmap.bpf.c
+++ b/tools/sched_ext/scx_qmap.bpf.c
@@ -35,7 +35,7 @@ const volatile s32 disallow_tgid;
 
 u32 test_error_cnt;
 
-struct user_exit_info uei;
+UEI_DEFINE(uei);
 
 struct qmap {
 	__uint(type, BPF_MAP_TYPE_QUEUE);
@@ -380,7 +380,7 @@ s32 BPF_STRUCT_OPS(qmap_init)
 
 void BPF_STRUCT_OPS(qmap_exit, struct scx_exit_info *ei)
 {
-	uei_record(&uei, ei);
+	UEI_RECORD(uei, ei);
 }
 
 SCX_OPS_DEFINE(qmap_ops,

--- a/tools/sched_ext/scx_qmap.bpf.c
+++ b/tools/sched_ext/scx_qmap.bpf.c
@@ -383,18 +383,27 @@ void BPF_STRUCT_OPS(qmap_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
+#define QMAP_OPS_INIT_COMMON							\
+	.select_cpu		= (void *)qmap_select_cpu,			\
+	.enqueue		= (void *)qmap_enqueue,				\
+	.dequeue		= (void *)qmap_dequeue,				\
+	.dispatch		= (void *)qmap_dispatch,			\
+	.core_sched_before	= (void *)qmap_core_sched_before,		\
+	.cpu_release		= (void *)qmap_cpu_release,			\
+	.init_task		= (void *)qmap_init_task,			\
+	.init			= (void *)qmap_init,				\
+	.exit			= (void *)qmap_exit,				\
+	.flags			= SCX_OPS_ENQ_LAST,				\
+	.timeout_ms		= 5000U,					\
+	.name			= "qmap",
+
 SEC(".struct_ops.link")
 struct sched_ext_ops qmap_ops = {
-	.select_cpu		= (void *)qmap_select_cpu,
-	.enqueue		= (void *)qmap_enqueue,
-	.dequeue		= (void *)qmap_dequeue,
-	.dispatch		= (void *)qmap_dispatch,
-	.core_sched_before	= (void *)qmap_core_sched_before,
-	.cpu_release		= (void *)qmap_cpu_release,
-	.init_task		= (void *)qmap_init_task,
-	.init			= (void *)qmap_init,
-	.exit			= (void *)qmap_exit,
-	.flags			= SCX_OPS_ENQ_LAST,
-	.timeout_ms		= 5000U,
-	.name			= "qmap",
+	QMAP_OPS_INIT_COMMON
+	/* .exit_dump_len will be set while loading */
+};
+
+SEC(".struct_ops.link")
+struct sched_ext_ops___no_exit_dump_len qmap_ops___no_exit_dump_len = {
+	QMAP_OPS_INIT_COMMON
 };

--- a/tools/sched_ext/scx_qmap.bpf.c
+++ b/tools/sched_ext/scx_qmap.bpf.c
@@ -383,27 +383,16 @@ void BPF_STRUCT_OPS(qmap_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-#define QMAP_OPS_INIT_COMMON							\
-	.select_cpu		= (void *)qmap_select_cpu,			\
-	.enqueue		= (void *)qmap_enqueue,				\
-	.dequeue		= (void *)qmap_dequeue,				\
-	.dispatch		= (void *)qmap_dispatch,			\
-	.core_sched_before	= (void *)qmap_core_sched_before,		\
-	.cpu_release		= (void *)qmap_cpu_release,			\
-	.init_task		= (void *)qmap_init_task,			\
-	.init			= (void *)qmap_init,				\
-	.exit			= (void *)qmap_exit,				\
-	.flags			= SCX_OPS_ENQ_LAST,				\
-	.timeout_ms		= 5000U,					\
-	.name			= "qmap",
-
-SEC(".struct_ops.link")
-struct sched_ext_ops qmap_ops = {
-	QMAP_OPS_INIT_COMMON
-	/* .exit_dump_len will be set while loading */
-};
-
-SEC(".struct_ops.link")
-struct sched_ext_ops___no_exit_dump_len qmap_ops___no_exit_dump_len = {
-	QMAP_OPS_INIT_COMMON
-};
+DEFINE_SCX_OPS(qmap_ops,
+	       .select_cpu		= (void *)qmap_select_cpu,
+	       .enqueue			= (void *)qmap_enqueue,
+	       .dequeue			= (void *)qmap_dequeue,
+	       .dispatch		= (void *)qmap_dispatch,
+	       .core_sched_before	= (void *)qmap_core_sched_before,
+	       .cpu_release		= (void *)qmap_cpu_release,
+	       .init_task		= (void *)qmap_init_task,
+	       .init			= (void *)qmap_init,
+	       .exit			= (void *)qmap_exit,
+	       .flags			= SCX_OPS_ENQ_LAST,
+	       .timeout_ms		= 5000U,
+	       .name			= "qmap");

--- a/tools/sched_ext/scx_qmap.bpf.c
+++ b/tools/sched_ext/scx_qmap.bpf.c
@@ -383,7 +383,7 @@ void BPF_STRUCT_OPS(qmap_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-DEFINE_SCX_OPS(qmap_ops,
+SCX_OPS_DEFINE(qmap_ops,
 	       .select_cpu		= (void *)qmap_select_cpu,
 	       .enqueue			= (void *)qmap_enqueue,
 	       .dequeue			= (void *)qmap_dequeue,

--- a/tools/sched_ext/scx_qmap.c
+++ b/tools/sched_ext/scx_qmap.c
@@ -88,10 +88,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	SCX_OPS_LOAD(skel, qmap_ops, scx_qmap);
+	SCX_OPS_LOAD(skel, qmap_ops, scx_qmap, uei);
 	link = SCX_OPS_ATTACH(skel, qmap_ops);
 
-	while (!exit_req && !uei_exited(&skel->bss->uei)) {
+	while (!exit_req && !UEI_EXITED(skel, uei)) {
 		long nr_enqueued = skel->bss->nr_enqueued;
 		long nr_dispatched = skel->bss->nr_dispatched;
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 	}
 
 	bpf_link__destroy(link);
-	uei_print(&skel->bss->uei);
+	UEI_REPORT(skel, uei);
 	scx_qmap__destroy(skel);
 	return 0;
 }

--- a/tools/sched_ext/scx_qmap.c
+++ b/tools/sched_ext/scx_qmap.c
@@ -19,7 +19,8 @@ const char help_fmt[] =
 "\n"
 "See the top-level comment in .bpf.c for more details.\n"
 "\n"
-"Usage: %s [-s SLICE_US] [-e COUNT] [-t COUNT] [-T COUNT] [-l COUNT] [-d PID] [-p]\n"
+"Usage: %s [-s SLICE_US] [-e COUNT] [-t COUNT] [-T COUNT] [-l COUNT] [-d PID]\n"
+"       [-D LEN] [-p]\n"
 "\n"
 "  -s SLICE_US   Override slice duration\n"
 "  -e COUNT      Trigger scx_bpf_error() after COUNT enqueues\n"
@@ -27,6 +28,7 @@ const char help_fmt[] =
 "  -T COUNT      Stall every COUNT'th kernel thread\n"
 "  -l COUNT      Trigger dispatch infinite looping after COUNT dispatches\n"
 "  -d PID        Disallow a process from switching into SCHED_EXT (-1 for self)\n"
+"  -D LEN        Set scx_exit_info.dump buffer length\n"
 "  -p            Switch only tasks on SCHED_EXT policy intead of all\n"
 "  -h            Display this help and exit\n";
 
@@ -39,6 +41,7 @@ static void sigint_handler(int dummy)
 
 int main(int argc, char **argv)
 {
+	bool has_ops_exit_dump_len = __COMPAT_KERNEL_HAS_OPS_EXIT_DUMP_LEN;
 	struct scx_qmap *skel;
 	struct bpf_link *link;
 	int opt;
@@ -51,7 +54,15 @@ int main(int argc, char **argv)
 	skel = scx_qmap__open();
 	SCX_BUG_ON(!skel, "Failed to open skel");
 
-	while ((opt = getopt(argc, argv, "s:e:t:T:l:d:ph")) != -1) {
+	if (has_ops_exit_dump_len) {
+		bpf_map__set_autocreate(skel->maps.qmap_ops, true);
+		bpf_map__set_autocreate(skel->maps.qmap_ops___no_exit_dump_len, false);
+	} else {
+		bpf_map__set_autocreate(skel->maps.qmap_ops, false);
+		bpf_map__set_autocreate(skel->maps.qmap_ops___no_exit_dump_len, true);
+	}
+
+	while ((opt = getopt(argc, argv, "s:e:t:T:l:d:D:ph")) != -1) {
 		switch (opt) {
 		case 's':
 			skel->rodata->slice_ns = strtoull(optarg, NULL, 0) * 1000;
@@ -73,6 +84,11 @@ int main(int argc, char **argv)
 			if (skel->rodata->disallow_tgid < 0)
 				skel->rodata->disallow_tgid = getpid();
 			break;
+		case 'D':
+			if (!has_ops_exit_dump_len)
+				fprintf(stderr, "WARNING: kernel doesn't support setting exit dump len\n");
+			skel->struct_ops.qmap_ops->exit_dump_len = strtoul(optarg, NULL, 0);
+			break;
 		case 'p':
 			skel->rodata->switch_partial = true;
 			skel->struct_ops.qmap_ops->flags |= __COMPAT_SCX_OPS_SWITCH_PARTIAL;
@@ -85,7 +101,11 @@ int main(int argc, char **argv)
 
 	SCX_BUG_ON(scx_qmap__load(skel), "Failed to load skel");
 
-	link = bpf_map__attach_struct_ops(skel->maps.qmap_ops);
+	if (has_ops_exit_dump_len)
+		link = bpf_map__attach_struct_ops(skel->maps.qmap_ops);
+	else
+		link = bpf_map__attach_struct_ops(skel->maps.qmap_ops___no_exit_dump_len);
+
 	SCX_BUG_ON(!link, "Failed to attach struct_ops");
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {

--- a/tools/sched_ext/scx_simple.bpf.c
+++ b/tools/sched_ext/scx_simple.bpf.c
@@ -27,7 +27,7 @@ char _license[] SEC("license") = "GPL";
 const volatile bool fifo_sched;
 
 static u64 vtime_now;
-struct user_exit_info uei;
+UEI_DEFINE(uei);
 
 #define SHARED_DSQ 0
 
@@ -134,7 +134,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(simple_init)
 
 void BPF_STRUCT_OPS(simple_exit, struct scx_exit_info *ei)
 {
-	uei_record(&uei, ei);
+	UEI_RECORD(uei, ei);
 }
 
 SCX_OPS_DEFINE(simple_ops,

--- a/tools/sched_ext/scx_simple.bpf.c
+++ b/tools/sched_ext/scx_simple.bpf.c
@@ -137,15 +137,13 @@ void BPF_STRUCT_OPS(simple_exit, struct scx_exit_info *ei)
 	uei_record(&uei, ei);
 }
 
-SEC(".struct_ops.link")
-struct sched_ext_ops simple_ops = {
-	.select_cpu		= (void *)simple_select_cpu,
-	.enqueue		= (void *)simple_enqueue,
-	.dispatch		= (void *)simple_dispatch,
-	.running		= (void *)simple_running,
-	.stopping		= (void *)simple_stopping,
-	.enable			= (void *)simple_enable,
-	.init			= (void *)simple_init,
-	.exit			= (void *)simple_exit,
-	.name			= "simple",
-};
+SCX_OPS_DEFINE(simple_ops,
+	       .select_cpu		= (void *)simple_select_cpu,
+	       .enqueue			= (void *)simple_enqueue,
+	       .dispatch		= (void *)simple_dispatch,
+	       .running			= (void *)simple_running,
+	       .stopping		= (void *)simple_stopping,
+	       .enable			= (void *)simple_enable,
+	       .init			= (void *)simple_init,
+	       .exit			= (void *)simple_exit,
+	       .name			= "simple");

--- a/tools/sched_ext/scx_simple.c
+++ b/tools/sched_ext/scx_simple.c
@@ -74,10 +74,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	SCX_OPS_LOAD(skel, simple_ops, scx_simple);
+	SCX_OPS_LOAD(skel, simple_ops, scx_simple, uei);
 	link = SCX_OPS_ATTACH(skel, simple_ops);
 
-	while (!exit_req && !uei_exited(&skel->bss->uei)) {
+	while (!exit_req && !UEI_EXITED(skel, uei)) {
 		__u64 stats[2];
 
 		read_stats(skel, stats);
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 	}
 
 	bpf_link__destroy(link);
-	uei_print(&skel->bss->uei);
+	UEI_REPORT(skel, uei);
 	scx_simple__destroy(skel);
 	return 0;
 }

--- a/tools/sched_ext/scx_simple.c
+++ b/tools/sched_ext/scx_simple.c
@@ -17,7 +17,7 @@ const char help_fmt[] =
 "\n"
 "See the top-level comment in .bpf.c for more details.\n"
 "\n"
-"Usage: %s [-f] [-p]\n"
+"Usage: %s [-f]\n"
 "\n"
 "  -f            Use FIFO scheduling instead of weighted vtime scheduling\n"
 "  -h            Display this help and exit\n";

--- a/tools/sched_ext/scx_simple.c
+++ b/tools/sched_ext/scx_simple.c
@@ -74,10 +74,8 @@ int main(int argc, char **argv)
 		}
 	}
 
-	SCX_BUG_ON(scx_simple__load(skel), "Failed to load skel");
-
-	link = bpf_map__attach_struct_ops(skel->maps.simple_ops);
-	SCX_BUG_ON(!link, "Failed to attach struct_ops");
+	SCX_OPS_LOAD(skel, simple_ops, scx_simple);
+	link = SCX_OPS_ATTACH(skel, simple_ops);
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {
 		__u64 stats[2];


### PR DESCRIPTION
Schedulers can now request custom debug dump buffer size by setting `sched_ext_ops.exit_dump_len`. This will help debugging on bigger and busier systems.