### PR TITLE
scx: Use cpu_online_mask when resetting idle masks

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -2215,9 +2215,12 @@ static void set_cpus_allowed_scx(struct task_struct *p,
 
 static void reset_idle_masks(void)
 {
-	/* consider all cpus idle, should converge to the actual state quickly */
-	cpumask_setall(idle_masks.cpu);
-	cpumask_setall(idle_masks.smt);
+	/*
+	 * Consider all online cpus idle. Should converge to the actual state
+	 * quickly.
+	 */
+	cpumask_copy(idle_masks.cpu, cpu_online_mask);
+	cpumask_copy(idle_masks.smt, cpu_online_mask);
 }
 
 void __scx_update_idle(struct rq *rq, bool idle)


### PR DESCRIPTION
reset_idle_masks() is called while loading a BPF scheduler to mark all CPUs as idle for scx_bpf_select_cpu_dfl(). It was cpumask_setall() which could make scx_bpf_select_cpu_dfl() pick a CPU which is possible but not online.

Note that such spurious picking can only happen one time and it's generally safe to pick an ineligible CPU, so nothing should be broken but the behavior isn't ideal. In general the initial values of idle masks aren't that important. They quickly get synchronized to the actual state through the CPUs entering and leaving the idle state.

However, let's still use cpu_online_mask instead so that the idle masks are initialized with online CPUs.