### PR TITLE
scx: Update selftests to use new UEI macros

### DIFF
--- a/tools/testing/selftests/sched_ext/ddsp_bogus_dsq_fail.bpf.c
+++ b/tools/testing/selftests/sched_ext/ddsp_bogus_dsq_fail.bpf.c
@@ -8,7 +8,7 @@
 
 char _license[] SEC("license") = "GPL";
 
-struct user_exit_info uei;
+UEI_DEFINE(uei);
 
 s32 BPF_STRUCT_OPS(ddsp_bogus_dsq_fail_select_cpu, struct task_struct *p,
 		   s32 prev_cpu, u64 wake_flags)
@@ -30,7 +30,7 @@ s32 BPF_STRUCT_OPS(ddsp_bogus_dsq_fail_select_cpu, struct task_struct *p,
 
 void BPF_STRUCT_OPS(ddsp_bogus_dsq_fail_exit, struct scx_exit_info *ei)
 {
-	uei_record(&uei, ei);
+	UEI_RECORD(uei, ei);
 }
 
 SEC(".struct_ops.link")

--- a/tools/testing/selftests/sched_ext/ddsp_bogus_dsq_fail.c
+++ b/tools/testing/selftests/sched_ext/ddsp_bogus_dsq_fail.c
@@ -32,7 +32,7 @@ static enum scx_test_status run(void *ctx)
 
 	sleep(1);
 
-	SCX_EQ(skel->bss->uei.kind, SCX_EXIT_ERROR);
+	SCX_EQ(skel->data->uei.kind, SCX_EXIT_ERROR);
 	bpf_link__destroy(link);
 
 	return SCX_TEST_PASS;

--- a/tools/testing/selftests/sched_ext/ddsp_vtimelocal_fail.bpf.c
+++ b/tools/testing/selftests/sched_ext/ddsp_vtimelocal_fail.bpf.c
@@ -8,7 +8,7 @@
 
 char _license[] SEC("license") = "GPL";
 
-struct user_exit_info uei;
+UEI_DEFINE(uei);
 
 s32 BPF_STRUCT_OPS(ddsp_vtimelocal_fail_select_cpu, struct task_struct *p,
 		   s32 prev_cpu, u64 wake_flags)
@@ -27,7 +27,7 @@ s32 BPF_STRUCT_OPS(ddsp_vtimelocal_fail_select_cpu, struct task_struct *p,
 
 void BPF_STRUCT_OPS(ddsp_vtimelocal_fail_exit, struct scx_exit_info *ei)
 {
-	uei_record(&uei, ei);
+	UEI_RECORD(uei, ei);
 }
 
 SEC(".struct_ops.link")

--- a/tools/testing/selftests/sched_ext/ddsp_vtimelocal_fail.c
+++ b/tools/testing/selftests/sched_ext/ddsp_vtimelocal_fail.c
@@ -31,7 +31,7 @@ static enum scx_test_status run(void *ctx)
 
 	sleep(1);
 
-	SCX_EQ(skel->bss->uei.kind, SCX_EXIT_ERROR);
+	SCX_EQ(skel->data->uei.kind, SCX_EXIT_ERROR);
 	bpf_link__destroy(link);
 
 	return SCX_TEST_PASS;

--- a/tools/testing/selftests/sched_ext/scx_test.h
+++ b/tools/testing/selftests/sched_ext/scx_test.h
@@ -92,7 +92,7 @@ void scx_test_register(struct scx_test *test);
 #define SCX_ERR(__fmt, ...)						\
 	do {								\
 		fprintf(stderr, "ERR: %s:%d\n", __FILE__, __LINE__);	\
-		fprintf(stderr, __fmt, ##__VA_ARGS__);			\
+		fprintf(stderr, __fmt"\n", ##__VA_ARGS__);			\
 	} while (0)
 
 #define SCX_FAIL(__fmt, ...)						\

--- a/tools/testing/selftests/sched_ext/select_cpu_dispatch_bad_dsq.bpf.c
+++ b/tools/testing/selftests/sched_ext/select_cpu_dispatch_bad_dsq.bpf.c
@@ -12,7 +12,7 @@
 
 char _license[] SEC("license") = "GPL";
 
-struct user_exit_info uei;
+UEI_DEFINE(uei);
 
 s32 BPF_STRUCT_OPS(select_cpu_dispatch_bad_dsq_select_cpu, struct task_struct *p,
 		   s32 prev_cpu, u64 wake_flags)
@@ -25,7 +25,7 @@ s32 BPF_STRUCT_OPS(select_cpu_dispatch_bad_dsq_select_cpu, struct task_struct *p
 
 void BPF_STRUCT_OPS(select_cpu_dispatch_bad_dsq_exit, struct scx_exit_info *ei)
 {
-	uei_record(&uei, ei);
+	UEI_RECORD(uei, ei);
 }
 
 SEC(".struct_ops.link")

--- a/tools/testing/selftests/sched_ext/select_cpu_dispatch_bad_dsq.c
+++ b/tools/testing/selftests/sched_ext/select_cpu_dispatch_bad_dsq.c
@@ -32,7 +32,7 @@ static enum scx_test_status run(void *ctx)
 
 	sleep(1);
 
-	SCX_EQ(skel->bss->uei.kind, SCX_EXIT_ERROR);
+	SCX_EQ(skel->data->uei.kind, SCX_EXIT_ERROR);
 	bpf_link__destroy(link);
 
 	return SCX_TEST_PASS;

--- a/tools/testing/selftests/sched_ext/select_cpu_dispatch_dbl_dsp.bpf.c
+++ b/tools/testing/selftests/sched_ext/select_cpu_dispatch_dbl_dsp.bpf.c
@@ -12,7 +12,7 @@
 
 char _license[] SEC("license") = "GPL";
 
-struct user_exit_info uei;
+UEI_DEFINE(uei);
 
 s32 BPF_STRUCT_OPS(select_cpu_dispatch_dbl_dsp_select_cpu, struct task_struct *p,
 		   s32 prev_cpu, u64 wake_flags)
@@ -26,7 +26,7 @@ s32 BPF_STRUCT_OPS(select_cpu_dispatch_dbl_dsp_select_cpu, struct task_struct *p
 
 void BPF_STRUCT_OPS(select_cpu_dispatch_dbl_dsp_exit, struct scx_exit_info *ei)
 {
-	uei_record(&uei, ei);
+	UEI_RECORD(uei, ei);
 }
 
 SEC(".struct_ops.link")

--- a/tools/testing/selftests/sched_ext/select_cpu_dispatch_dbl_dsp.c
+++ b/tools/testing/selftests/sched_ext/select_cpu_dispatch_dbl_dsp.c
@@ -32,7 +32,7 @@ static enum scx_test_status run(void *ctx)
 
 	sleep(1);
 
-	SCX_EQ(skel->bss->uei.kind, SCX_EXIT_ERROR);
+	SCX_EQ(skel->data->uei.kind, SCX_EXIT_ERROR);
 	bpf_link__destroy(link);
 
 	return SCX_TEST_PASS;


### PR DESCRIPTION
The UEI macros were updated in a prior commit. Apply the changes to the sched_ext selftests dir.

Some of the tests are now broken as well. We should investigate.