### PR TITLE
scx: Add hotplug sequence number

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -26,7 +26,7 @@ struct scx_exit_info {
 	/* %SCX_EXIT_* - broad category of the exit reason */
 	enum scx_exit_kind	kind;
 
-	/* exit code if gracefully exiting from BPF */
+	/* exit code if gracefully exiting */
 	s64			exit_code;
 
 	/* textual representation of the above */
@@ -6068,7 +6068,7 @@ static int __init scx_init(void)
 
 	scx_kset = kset_create_and_add("sched_ext", &scx_uevent_ops, kernel_kobj);
 	if (!scx_kset) {
-		pr_err("sched_ext: Failed to create /sys/sched_ext\n");
+		pr_err("sched_ext: Failed to create /sys/kernel/sched_ext\n");
 		return -ENOMEM;
 	}
 

--- a/tools/sched_ext/include/scx/compat.h
+++ b/tools/sched_ext/include/scx/compat.h
@@ -8,6 +8,9 @@
 #define __SCX_COMPAT_H
 
 #include <bpf/btf.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 struct btf *__COMPAT_vmlinux_btf __attribute__((weak));
 
@@ -106,16 +109,55 @@ static inline bool __COMPAT_struct_has_field(const char *type, const char *field
 #define __COMPAT_SCX_OPS_SWITCH_PARTIAL						\
 	__COMPAT_ENUM_OR_ZERO("scx_ops_flags", "SCX_OPS_SWITCH_PARTIAL")
 
+static inline long scx_hotplug_seq(void)
+{
+	int fd;
+	char buf[32];
+	ssize_t len;
+	long val;
+
+	fd = open("/sys/kernel/sched_ext/hotplug_seq", O_RDONLY);
+	if (fd < 0)
+		return -ENOENT;
+
+	len = read(fd, buf, sizeof(buf) - 1);
+	SCX_BUG_ON(len <= 0, "read failed (%ld)", len);
+	buf[len] = 0;
+	close(fd);
+
+	val = strtoul(buf, NULL, 10);
+	SCX_BUG_ON(val < 0, "invalid num hotplug events: %lu", val);
+
+	return val;
+}
+
 /*
  * struct sched_ext_ops can change over time. If compat.bpf.h::SCX_OPS_DEFINE()
  * is used to define ops and compat.h::SCX_OPS_LOAD/ATTACH() are used to load
  * and attach it, backward compatibility is automatically maintained where
  * reasonable.
  *
- * - sched_ext_ops.exit_dump_len was added later. On kernels which don't support
- *   it, the value is ignored and a warning is triggered if the value is
- *   requested to be non-zero.
+ * The following values were added in newer kernels:
+ *
+ * - sched_ext_ops.exit_dump_len
+ *	o If nonzero and running on an older kernel, the value is set to zero
+ *	  and a warning is emitted
+ *
+ * - sched_ext_ops.hotplug_sqn
+ *	o If nonzero and running on an older kernel, the scheduler will fail to
+ *	  load
  */
+#define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
+	struct __scx_name *__skel;						\
+										\
+	__skel = __scx_name##__open();						\
+	SCX_BUG_ON(!__skel, "Could not open " #__scx_name);			\
+										\
+	if (__COMPAT_struct_has_field("sched_ext_ops", "hotplug_seq"))		\
+		__skel->struct_ops.__ops_name->hotplug_seq = scx_hotplug_seq();	\
+	__skel; 								\
+})
+
 #define SCX_OPS_LOAD(__skel, __ops_name, __scx_name, __uei_name) ({		\
 	UEI_SET_SIZE(__skel, __ops_name, __uei_name);				\
 	if (__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len") &&	\

--- a/tools/testing/selftests/sched_ext/util.h
+++ b/tools/testing/selftests/sched_ext/util.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
  * Copyright (c) 2024 Meta Platforms, Inc. and affiliates.
- * Copyright (c) 2024 Tejun Heo <tj@kernel.org>
+ * Copyright (c) 2024 David Vernet <void@manifault.com>
  */
 
 #ifndef __SCX_TEST_UTIL_H__


### PR DESCRIPTION
We currently have a possibly tricky race w.r.t. hotplug that schedulers
don't have a good way to account for. Once a scheduler has inspected a
host topology, if a hotplug event occurs before a scheduler is attached
and loaded, then the scheduler will have no way of knowing that its view
of the host topology is incorrect. Hotplug events _after_ this are fine,
as we'll either pass the events to the scheduler, or evict the scheduler
directly. But if a hotplug event happens between inspecting the host
topology and attaching the scheduler, we have a problem.

This series addresses this by adding the capability to track a
monotonically increasing sequence number across hotplug events.