### PR TITLE
scx: Mark sched_ext uclamp enabled

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3660,7 +3660,7 @@ DEFINE_SCHED_CLASS(ext) = {
 	.update_curr		= update_curr_scx,
 
 #ifdef CONFIG_UCLAMP_TASK
-	.uclamp_enabled		= 0,
+	.uclamp_enabled		= 1,
 #endif
 };
 


### PR DESCRIPTION
No reason not to.