### PR TITLE
Run selftests in scx CI

### DIFF
--- a/.github/workflows/run-schedulers
+++ b/.github/workflows/run-schedulers
@@ -59,3 +59,14 @@ for sched in $(find tools/sched_ext/build/bin -type f -executable); do
         echo "OK: ${sched}"
     fi
 done
+
+# Run the selftests suite
+runtest "tools/testing/selftests/sched_ext/runner"
+sed -n -e '/not ok/q1' /tmp/output
+res=$?
+if [ ${res} -ne 0 ]; then
+	echo "FAIL: selftests"
+	echo "output: $(cat /tmp/output)"
+else
+	echo "OK: selftests"
+fi

--- a/.github/workflows/run-schedulers
+++ b/.github/workflows/run-schedulers
@@ -16,6 +16,26 @@ if [ ! -x `which vng` ]; then
     exit 1
 fi
 
+function runtest() {
+    local bin="${1}"
+
+    if [ -z "${bin}" ]; then
+        echo "No binary passed to runtest"
+        exit 1
+    fi
+
+    if ! [ -f "${bin}" ]; then
+        echo "Binary ${bin} was not a regular file"
+        exit 1
+    fi
+
+    rm -f /tmp/output
+    (timeout --foreground --preserve-status ${GUEST_TIMEOUT} \
+        vng --force-9p --disable-microvm --verbose -- \
+            "timeout --foreground --preserve-status ${TEST_TIMEOUT} ${bin}" \
+                2>&1 </dev/null || true) | tee /tmp/output
+}
+
 # Test all the available schedulers.
 #
 # NOTE: virtme-ng automatically runs the kernel from the current working
@@ -24,18 +44,8 @@ fi
 # Each scheduler will be tested in a separate instance booted from scratch, to
 # ensure that each run does not impact the others.
 #
-# TODO: exclude scx_layered for now, because it requires a special config
-# file, otherwise its test would fail with "Error: No layer spec".
-#
-# Maybe in the future change scx_layered to run with a default layer spec, just
-# for testing it.
-#
-for sched in $(find tools/sched_ext/build/bin -type f -executable | grep -v scx_layered); do
-    rm -f /tmp/output
-    (timeout --foreground --preserve-status ${GUEST_TIMEOUT} \
-        vng --force-9p --disable-microvm --verbose -- \
-            "timeout --foreground --preserve-status ${TEST_TIMEOUT} ${sched}" \
-                2>&1 </dev/null || true) | tee /tmp/output
+for sched in $(find tools/sched_ext/build/bin -type f -executable); do
+    runtest "${sched}"
     sed -n -e '/\bBUG:/q1' \
            -e '/\bWARNING:/q1' \
            -e '/\berror\b/Iq1' \

--- a/.github/workflows/test-kernel.yml
+++ b/.github/workflows/test-kernel.yml
@@ -40,8 +40,11 @@ jobs:
       # Build a minimal kernel (with sched-ext enabled) using virtme-ng
       - run: vng -v --build --config .github/workflows/sched-ext.config
 
+      # Build the selftests suite
+      - run: make -j $(nproc) -C tools/testing/selftests/sched_ext
+
       # Build the in-kernel schedulers
-      - run: cd tools/sched_ext && make
+      - run: make -j $(nproc) -C tools/sched_ext
 
       # Test the schedulers inside the recompile kernel
       - run: .github/workflows/run-schedulers

--- a/.github/workflows/test-kernel.yml
+++ b/.github/workflows/test-kernel.yml
@@ -16,7 +16,7 @@ jobs:
       ### DOWNLOAD AND INSTALL DEPENDENCIES ###
 
       # Download dependencies packaged by Ubuntu
-      - run: sudo apt -y install gcc make git coreutils cmake elfutils libelf-dev libunwind-dev libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic ninja-build python3-pip python3-requests qemu-kvm udev iproute2 busybox-static libvirt-clients kbd kmod file rsync zstd pahole flex bison cpio libcap-dev libelf-dev python3-dev cargo rustc
+      - run: sudo apt -y install bc gcc make git coreutils cmake elfutils libelf-dev libunwind-dev libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic ninja-build python3-pip python3-requests qemu-kvm udev iproute2 busybox-static libvirt-clients kbd kmod file rsync zstd pahole flex bison cpio libcap-dev libelf-dev python3-dev cargo rustc gcc-multilib
 
       # clang 17
       # Use a custom llvm.sh script which includes the -y flag for

--- a/tools/testing/selftests/sched_ext/hotplug.c
+++ b/tools/testing/selftests/sched_ext/hotplug.c
@@ -83,8 +83,8 @@ static enum scx_test_status test_hotplug(bool onlining, bool cbs_defined)
 	while (!UEI_EXITED(skel, uei))
 		sched_yield();
 
-	SCX_EQ(UEI_KIND(skel, uei), kind);
-	SCX_EQ(UEI_ECODE(skel, uei), code);
+	SCX_EQ(skel->data->uei.kind, kind);
+	SCX_EQ(UEI_REPORT(skel, uei), code);
 
 	if (!onlining)
 		toggle_online_status(1);
@@ -126,8 +126,8 @@ static enum scx_test_status test_hotplug_attach(void)
 	kind = SCX_KIND_VAL(SCX_EXIT_UNREG_KERN);
 	code = SCX_ECODE_VAL(SCX_ECODE_ACT_RESTART) |
 	       SCX_ECODE_VAL(SCX_ECODE_RSN_HOTPLUG);
-	SCX_EQ(UEI_KIND(skel, uei), kind);
-	SCX_EQ(UEI_ECODE(skel, uei), code);
+	SCX_EQ(skel->data->uei.kind, kind);
+	SCX_EQ(UEI_REPORT(skel, uei), code);
 
 	bpf_link__destroy(link);
 	hotplug__destroy(skel);


### PR DESCRIPTION
We have a fairly comprehensive set of selftests in
tools/selftests/sched_ext. Let's run them in CI to
avoid breakages.