### PR TITLE
Implement `ops.dump()`, `dump_cpu()` and `dump_task()`.

### DIFF
--- a/tools/sched_ext/include/scx/common.bpf.h
+++ b/tools/sched_ext/include/scx/common.bpf.h
@@ -78,14 +78,14 @@ static inline bool scx_bpf_consume_task(struct bpf_iter_scx_dsq *it,
 }
 
 static inline __attribute__((format(printf, 1, 2)))
-void ___scx_bpf_exit_format_checker(const char *fmt, ...) {}
+void ___scx_bpf_bstr_format_checker(const char *fmt, ...) {}
 
 /*
  * Helper macro for initializing the fmt and variadic argument inputs to both
  * bstr exit kfuncs. Callers to this function should use ___fmt and ___param to
  * refer to the initialized list of inputs to the bstr kfunc.
  */
-#define scx_bpf_exit_preamble(fmt, args...)					\
+#define scx_bpf_bstr_preamble(fmt, args...)					\
 	static char ___fmt[] = fmt;						\
 	/*									\
 	 * Note that __param[] must have at least one				\
@@ -105,9 +105,9 @@ void ___scx_bpf_exit_format_checker(const char *fmt, ...) {}
  */
 #define scx_bpf_exit(code, fmt, args...)					\
 ({										\
-	scx_bpf_exit_preamble(fmt, args)					\
+	scx_bpf_bstr_preamble(fmt, args)					\
 	scx_bpf_exit_bstr(code, ___fmt, ___param, sizeof(___param));		\
-	___scx_bpf_exit_format_checker(fmt, ##args);				\
+	___scx_bpf_bstr_format_checker(fmt, ##args);				\
 })
 
 /*
@@ -118,9 +118,9 @@ void ___scx_bpf_exit_format_checker(const char *fmt, ...) {}
  */
 #define scx_bpf_error(fmt, args...)						\
 ({										\
-	scx_bpf_exit_preamble(fmt, args)					\
+	scx_bpf_bstr_preamble(fmt, args)					\
 	scx_bpf_error_bstr(___fmt, ___param, sizeof(___param));			\
-	___scx_bpf_exit_format_checker(fmt, ##args);				\
+	___scx_bpf_bstr_format_checker(fmt, ##args);				\
 })
 
 #define BPF_STRUCT_OPS(name, args...)						\

--- a/tools/sched_ext/include/scx/common.bpf.h
+++ b/tools/sched_ext/include/scx/common.bpf.h
@@ -45,6 +45,7 @@ struct task_struct *bpf_iter_scx_dsq_next(struct bpf_iter_scx_dsq *it) __ksym __
 void bpf_iter_scx_dsq_destroy(struct bpf_iter_scx_dsq *it) __ksym __weak;
 void scx_bpf_exit_bstr(s64 exit_code, char *fmt, unsigned long long *data, u32 data__sz) __ksym __weak;
 void scx_bpf_error_bstr(char *fmt, unsigned long long *data, u32 data_len) __ksym;
+void scx_bpf_dump_bstr(char *fmt, unsigned long long *data, u32 data_len) __ksym;
 u32 scx_bpf_cpuperf_cap(s32 cpu) __ksym __weak;
 u32 scx_bpf_cpuperf_cur(s32 cpu) __ksym __weak;
 void scx_bpf_cpuperf_set(s32 cpu, u32 perf) __ksym __weak;
@@ -120,6 +121,17 @@ void ___scx_bpf_bstr_format_checker(const char *fmt, ...) {}
 ({										\
 	scx_bpf_bstr_preamble(fmt, args)					\
 	scx_bpf_error_bstr(___fmt, ___param, sizeof(___param));			\
+	___scx_bpf_bstr_format_checker(fmt, ##args);				\
+})
+
+/*
+ * scx_bpf_dump() wraps the scx_bpf_dump_bstr() kfunc with variadic arguments
+ * instead of an array of u64. To be used from ops.dump() and friends.
+ */
+#define scx_bpf_dump(fmt, args...)						\
+({										\
+	scx_bpf_bstr_preamble(fmt, args)					\
+	scx_bpf_dump_bstr(___fmt, ___param, sizeof(___param));			\
 	___scx_bpf_bstr_format_checker(fmt, ##args);				\
 })
 

--- a/tools/sched_ext/include/scx/compat.h
+++ b/tools/sched_ext/include/scx/compat.h
@@ -158,6 +158,7 @@ static inline long scx_hotplug_seq(void)
  * reasonable.
  *
  * - ops.tick(): Ignored on older kernels with a warning.
+ * - ops.dump*(): Ignored on older kernels with a warning.
  * - ops.exit_dump_len: Cleared to zero on older kernels with a warning.
  * - ops.hotplug_seq: Ignored on older kernels.
  */
@@ -183,6 +184,15 @@ static inline long scx_hotplug_seq(void)
 	    (__skel)->struct_ops.__ops_name->tick) {				\
 		fprintf(stderr, "WARNING: kernel doesn't support ops.tick()\n"); \
 		(__skel)->struct_ops.__ops_name->tick = NULL;			\
+	}									\
+	if (!__COMPAT_struct_has_field("sched_ext_ops", "dump") &&		\
+	    ((__skel)->struct_ops.__ops_name->dump ||				\
+	     (__skel)->struct_ops.__ops_name->dump_cpu ||			\
+	     (__skel)->struct_ops.__ops_name->dump_task)) {			\
+		fprintf(stderr, "WARNING: kernel doesn't support ops.dump*()\n"); \
+		(__skel)->struct_ops.__ops_name->dump = NULL;			\
+		(__skel)->struct_ops.__ops_name->dump_cpu = NULL;		\
+		(__skel)->struct_ops.__ops_name->dump_task = NULL;		\
 	}									\
 	SCX_BUG_ON(__scx_name##__load((__skel)), "Failed to load skel");	\
 })

--- a/tools/sched_ext/scx_qmap.bpf.c
+++ b/tools/sched_ext/scx_qmap.bpf.c
@@ -40,6 +40,7 @@ const volatile u32 dsp_batch;
 const volatile bool print_shared_dsq;
 const volatile char exp_prefix[17];
 const volatile s32 disallow_tgid;
+const volatile bool suppress_dump;
 const volatile bool switch_partial;
 
 u32 test_error_cnt;
@@ -462,6 +463,57 @@ s32 BPF_STRUCT_OPS(qmap_init_task, struct task_struct *p,
 		return -ENOMEM;
 }
 
+void BPF_STRUCT_OPS(qmap_dump, struct scx_dump_ctx *dctx)
+{
+	s32 i, pid;
+
+	if (suppress_dump)
+		return;
+
+	bpf_for(i, 0, 5) {
+		void *fifo;
+
+		if (!(fifo = bpf_map_lookup_elem(&queue_arr, &i)))
+			return;
+
+		scx_bpf_dump("QMAP FIFO[%d]:", i);
+		bpf_repeat(4096) {
+			if (bpf_map_pop_elem(fifo, &pid))
+				break;
+			scx_bpf_dump(" %d", pid);
+		}
+		scx_bpf_dump("\n");
+	}
+}
+
+void BPF_STRUCT_OPS(qmap_dump_cpu, struct scx_dump_ctx *dctx, s32 cpu, bool idle)
+{
+	u32 zero = 0;
+	struct cpu_ctx *cpuc;
+
+	if (suppress_dump || idle)
+		return;
+	if (!(cpuc = bpf_map_lookup_percpu_elem(&cpu_ctx_stor, &zero, cpu)))
+		return;
+
+	scx_bpf_dump("QMAP: dsp_idx=%llu dsp_cnt=%llu avg_weight=%u cpuperf_target=%u",
+		     cpuc->dsp_idx, cpuc->dsp_cnt, cpuc->avg_weight,
+		     cpuc->cpuperf_target);
+}
+
+void BPF_STRUCT_OPS(qmap_dump_task, struct scx_dump_ctx *dctx, struct task_struct *p)
+{
+	struct task_ctx *taskc;
+
+	if (suppress_dump)
+		return;
+	if (!(taskc = bpf_task_storage_get(&task_ctx_stor, p, 0, 0)))
+		return;
+
+	scx_bpf_dump("QMAP: force_local=%d core_sched_seq=%llu",
+		     taskc->force_local, taskc->core_sched_seq);
+}
+
 /*
  * Print out the online and possible CPU map using bpf_printk() as a
  * demonstration of using the cpumask kfuncs and ops.cpu_on/offline().
@@ -664,6 +716,9 @@ SCX_OPS_DEFINE(qmap_ops,
 	       .core_sched_before	= (void *)qmap_core_sched_before,
 	       .cpu_release		= (void *)qmap_cpu_release,
 	       .init_task		= (void *)qmap_init_task,
+	       .dump			= (void *)qmap_dump,
+	       .dump_cpu		= (void *)qmap_dump_cpu,
+	       .dump_task		= (void *)qmap_dump_task,
 	       .cpu_online		= (void *)qmap_cpu_online,
 	       .cpu_offline		= (void *)qmap_cpu_offline,
 	       .init			= (void *)qmap_init,

--- a/tools/sched_ext/scx_qmap.c
+++ b/tools/sched_ext/scx_qmap.c
@@ -33,6 +33,7 @@ const char help_fmt[] =
 "                (e.g. match shell on a loaded system)\n"
 "  -d PID        Disallow a process from switching into SCHED_EXT (-1 for self)\n"
 "  -D LEN        Set scx_exit_info.dump buffer length\n"
+"  -S            Suppress qmap-specific debug dump\n"
 "  -p            Switch only tasks on SCHED_EXT policy intead of all\n"
 "  -v            Print libbpf debug messages\n"
 "  -h            Display this help and exit\n";
@@ -64,7 +65,7 @@ int main(int argc, char **argv)
 
 	skel = SCX_OPS_OPEN(qmap_ops, scx_qmap);
 
-	while ((opt = getopt(argc, argv, "s:e:t:T:l:b:PE:d:D:pvh")) != -1) {
+	while ((opt = getopt(argc, argv, "s:e:t:T:l:b:PE:d:D:Spvh")) != -1) {
 		switch (opt) {
 		case 's':
 			skel->rodata->slice_ns = strtoull(optarg, NULL, 0) * 1000;
@@ -98,6 +99,9 @@ int main(int argc, char **argv)
 			break;
 		case 'D':
 			skel->struct_ops.qmap_ops->exit_dump_len = strtoul(optarg, NULL, 0);
+			break;
+		case 'S':
+			skel->rodata->suppress_dump = true;
 			break;
 		case 'p':
 			skel->rodata->switch_partial = true;


### PR DESCRIPTION
Implement ops.dump(), dump_cpu() and dump_task() which allows the BPF
scheduler to include scheduler specific information in debug dump.

The below example output from scx_qmap shows full dump of qmap's FIFO queues
and per-CPU and per-task contexts.
```
  $ scx_qmap -e 3
  stats  : enq=9 dsp=0 delta=9 reenq=5 deq=9 core=0 exp=0
  cpuperf: cur min/avg/max=0/0/0 target min/avg/max=0/0/0

  DEBUG DUMP
  ================================================================================

  scx_qmap[1627] triggered exit kind 1025:
    scx_bpf_error (test triggering error)

  Backtrace:
    scx_bpf_error_bstr+0x60/0x80
    bpf_prog_5ab320c9dc9e846d_qmap_enqueue+0xd1/0x283

  QMAP FIFO[0]:
  QMAP FIFO[1]:
  QMAP FIFO[2]: 1581 1583 1584 1585 1586 1588 1593 1594 1595
  QMAP FIFO[3]:
  QMAP FIFO[4]:

  CPU states
  ----------

  CPU 0   : nr_run=2 flags=0x0 cpu_rel=1 ops_qseq=4 pnt_seq=12
	    curr=stress[1590] class=ext_sched_class

    QMAP: dsp_idx=0 dsp_cnt=0 avg_weight=0 cpuperf_target=0

   *R stress[1590] +0ms
	scx_state/flags=3/0x5 dsq_flags=0x0 ops_state/qseq=0/0
	sticky/holding_cpu=-1/-1 dsq_id=(n/a)
	cpus=ff

      QMAP: force_local=0 core_sched_seq=0

    R stress[1585] +0ms
	scx_state/flags=3/0x1 dsq_flags=0x0 ops_state/qseq=2/3
	sticky/holding_cpu=-1/-1 dsq_id=(n/a)
	cpus=ff

      QMAP: force_local=0 core_sched_seq=3

      irqentry_exit+0x31/0x80
      sysvec_apic_timer_interrupt+0x44/0x80
      asm_sysvec_apic_timer_interrupt+0x1b/0x20
  ...
```