### PR TITLE
ci: enable kvm support in the github workflow

### DIFF
--- a/.github/workflows/run-schedulers
+++ b/.github/workflows/run-schedulers
@@ -31,7 +31,7 @@ function runtest() {
 
     rm -f /tmp/output
     (timeout --foreground --preserve-status ${GUEST_TIMEOUT} \
-        vng --force-9p --disable-microvm --verbose -- \
+        vng --force-9p --verbose -- \
             "timeout --foreground --preserve-status ${TEST_TIMEOUT} ${bin}" \
                 2>&1 </dev/null || true) | tee /tmp/output
 }
@@ -46,11 +46,12 @@ function runtest() {
 #
 for sched in $(find tools/sched_ext/build/bin -type f -executable); do
     runtest "${sched}"
-    sed -n -e '/\bBUG:/q1' \
-           -e '/\bWARNING:/q1' \
-           -e '/\berror\b/Iq1' \
-           -e '/\bstall/Iq1' \
-           -e '/\btimeout\b/Iq1' /tmp/output
+    grep -v " Speculative Return Stack Overflow" /tmp/output | \
+        sed -n -e '/\bBUG:/q1' \
+            -e '/\bWARNING:/q1' \
+            -e '/\berror\b/Iq1' \
+            -e '/\bstall/Iq1' \
+            -e '/\btimeout\b/Iq1'
     res=$?
     if [ ${res} -ne 0 ]; then
         echo "FAIL: ${sched}"

--- a/.github/workflows/test-kernel.yml
+++ b/.github/workflows/test-kernel.yml
@@ -46,5 +46,11 @@ jobs:
       # Build the in-kernel schedulers
       - run: make -j $(nproc) -C tools/sched_ext
 
+      # Setup KVM support
+      - run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       # Test the schedulers inside the recompile kernel
       - run: .github/workflows/run-schedulers


### PR DESCRIPTION
Enable kvm acceleration and qemu microvm to speed up CI tests inside virtme-ng.

Also adjust the regex to catch potential errors excluding a false positive triggered by the new configuration.

Link: https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
Link: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/