### PR TITLE
Improve debug dump

### DIFF
--- a/Documentation/scheduler/sched-ext.rst
+++ b/Documentation/scheduler/sched-ext.rst
@@ -18,6 +18,13 @@ programs - the BPF scheduler.
   a runnable task stalls, or on invoking the SysRq key sequence
   :kbd:`SysRq-S`.
 
+* When the BPF scheduler triggers an error, debug information is dumped to
+  aid debugging. The debug dump is passed to and printed out by the
+  scheduler binary. The debug dump can also be accessed through the
+  `sched_ext_dump` tracepoint. The SysRq key sequence :kbd:`SysRq-D`
+  triggers a debug dump. This doesn't terminate the BPF scheduler and can
+  only be read through the tracepoint.
+
 Switching to and from sched_ext
 ===============================
 

--- a/include/trace/events/sched_ext.h
+++ b/include/trace/events/sched_ext.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM sched_ext
+
+#if !defined(_TRACE_SCHED_EXT_H) || defined(TRACE_HEADER_MULTI_READ)
+#define _TRACE_SCHED_EXT_H
+
+#include <linux/tracepoint.h>
+
+TRACE_EVENT(sched_ext_dump,
+
+	TP_PROTO(const char *line),
+
+	TP_ARGS(line),
+
+	TP_STRUCT__entry(
+		__string(line, line)
+	),
+
+	TP_fast_assign(
+		__assign_str(line, line);
+	),
+
+	TP_printk("%s",
+		__get_str(line)
+	)
+);
+
+#endif /* _TRACE_SCHED_EXT_H */
+
+/* This part must be outside protection */
+#include <trace/define_trace.h>

--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -4648,8 +4648,9 @@ static void scx_dump_task(struct seq_buf *s, struct scx_dump_ctx *dctx,
 		  scx_get_task_state(p), p->scx.flags & ~SCX_TASK_STATE_MASK,
 		  p->scx.dsq_node.flags, ops_state & SCX_OPSS_STATE_MASK,
 		  ops_state >> SCX_OPSS_QSEQ_SHIFT);
-	dump_line(s, "      sticky/holding_cpu=%d/%d dsq_id=%s",
-		    p->scx.sticky_cpu, p->scx.holding_cpu, dsq_id_buf);
+	dump_line(s, "      sticky/holding_cpu=%d/%d dsq_id=%s dsq_vtime=%llu",
+		  p->scx.sticky_cpu, p->scx.holding_cpu, dsq_id_buf,
+		  p->scx.dsq_vtime);
 	dump_line(s, "      cpus=%*pb", cpumask_pr_args(p->cpus_ptr));
 
 	if (SCX_HAS_OP(dump_task)) {

--- a/tools/sched_ext/include/scx/common.bpf.h
+++ b/tools/sched_ext/include/scx/common.bpf.h
@@ -45,7 +45,7 @@ struct task_struct *bpf_iter_scx_dsq_next(struct bpf_iter_scx_dsq *it) __ksym __
 void bpf_iter_scx_dsq_destroy(struct bpf_iter_scx_dsq *it) __ksym __weak;
 void scx_bpf_exit_bstr(s64 exit_code, char *fmt, unsigned long long *data, u32 data__sz) __ksym __weak;
 void scx_bpf_error_bstr(char *fmt, unsigned long long *data, u32 data_len) __ksym;
-void scx_bpf_dump_bstr(char *fmt, unsigned long long *data, u32 data_len) __ksym;
+void scx_bpf_dump_bstr(char *fmt, unsigned long long *data, u32 data_len) __ksym __weak;
 u32 scx_bpf_cpuperf_cap(s32 cpu) __ksym __weak;
 u32 scx_bpf_cpuperf_cur(s32 cpu) __ksym __weak;
 void scx_bpf_cpuperf_set(s32 cpu, u32 perf) __ksym __weak;

--- a/tools/sched_ext/include/scx/compat.bpf.h
+++ b/tools/sched_ext/include/scx/compat.bpf.h
@@ -43,9 +43,19 @@ static inline void __COMPAT_scx_bpf_switch_all(void)
 #define __COMPAT_scx_bpf_exit(code, fmt, args...)				\
 ({										\
 	if (bpf_ksym_exists(scx_bpf_exit_bstr))					\
-		scx_bpf_exit((code), fmt, args);				\
+		scx_bpf_exit((code), fmt, ##args);				\
 	else									\
-		scx_bpf_error(fmt, args);					\
+		scx_bpf_error(fmt, ##args);					\
+})
+
+/*
+ * scx_bpf_dump() is a new addition. Ignore if unavailable. Users can use
+ * scx_bpf_dump() directly in the future.
+ */
+#define __COMPAT_scx_bpf_dump(fmt, args...)					\
+({										\
+	if (bpf_ksym_exists(scx_bpf_dump_bstr))					\
+		scx_bpf_dump(fmt, ##args);					\
 })
 
 /*

--- a/tools/sched_ext/scx_qmap.bpf.c
+++ b/tools/sched_ext/scx_qmap.bpf.c
@@ -476,13 +476,13 @@ void BPF_STRUCT_OPS(qmap_dump, struct scx_dump_ctx *dctx)
 		if (!(fifo = bpf_map_lookup_elem(&queue_arr, &i)))
 			return;
 
-		scx_bpf_dump("QMAP FIFO[%d]:", i);
+		__COMPAT_scx_bpf_dump("QMAP FIFO[%d]:", i);
 		bpf_repeat(4096) {
 			if (bpf_map_pop_elem(fifo, &pid))
 				break;
-			scx_bpf_dump(" %d", pid);
+			__COMPAT_scx_bpf_dump(" %d", pid);
 		}
-		scx_bpf_dump("\n");
+		__COMPAT_scx_bpf_dump("\n");
 	}
 }
 
@@ -496,9 +496,9 @@ void BPF_STRUCT_OPS(qmap_dump_cpu, struct scx_dump_ctx *dctx, s32 cpu, bool idle
 	if (!(cpuc = bpf_map_lookup_percpu_elem(&cpu_ctx_stor, &zero, cpu)))
 		return;
 
-	scx_bpf_dump("QMAP: dsp_idx=%llu dsp_cnt=%llu avg_weight=%u cpuperf_target=%u",
-		     cpuc->dsp_idx, cpuc->dsp_cnt, cpuc->avg_weight,
-		     cpuc->cpuperf_target);
+	__COMPAT_scx_bpf_dump("QMAP: dsp_idx=%llu dsp_cnt=%llu avg_weight=%u cpuperf_target=%u",
+			      cpuc->dsp_idx, cpuc->dsp_cnt, cpuc->avg_weight,
+			      cpuc->cpuperf_target);
 }
 
 void BPF_STRUCT_OPS(qmap_dump_task, struct scx_dump_ctx *dctx, struct task_struct *p)
@@ -510,8 +510,8 @@ void BPF_STRUCT_OPS(qmap_dump_task, struct scx_dump_ctx *dctx, struct task_struc
 	if (!(taskc = bpf_task_storage_get(&task_ctx_stor, p, 0, 0)))
 		return;
 
-	scx_bpf_dump("QMAP: force_local=%d core_sched_seq=%llu",
-		     taskc->force_local, taskc->core_sched_seq);
+	__COMPAT_scx_bpf_dump("QMAP: force_local=%d core_sched_seq=%llu",
+			      taskc->force_local, taskc->core_sched_seq);
 }
 
 /*


### PR DESCRIPTION
- Dumps can now be read through `sched_ext_dump` tracepoint.
- Dumps can now be triggered non-destructively using `sysrq-D`.