### PR TITLE
scx: Branchless implementation of highest_bit

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -1017,7 +1017,7 @@ static u32 higher_bits(u32 flags)
 static u32 highest_bit(u32 flags)
 {
 	int bit = fls(flags);
-	return bit ? 1 << (bit - 1) : 0;
+	return ((u64) 1 << bit) >> 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
Origin implementation of function `highest_bit` utilize the function of `fls()` to calculate the most significant bit of the input parameter `flags`. Normally we can return the mask with `1 << (fls(flags) - 1)`, but `fls(flags)` will return 0 if the value of `flags` is 0, which will cause the evaluation become `1 << (-1)` and it's illegal. So we use a branch to determine whether the return value of `fls(flags)` is 0.

We can remove the use of branch first left shift `fls(flags)` number of bits and then right shift 1 bit. When the value of `fls(flags)` is 0 then this evaluation will simply become 0 without any error. As more values other than 0, evaluation is the same as it did for `1 << (fls(flags) - 1)`.

This implementation can prevent any possible branch prediction fault and pure shift operations are cheaper than branch operation for if-else statements.

## Experiments
### Correctness
In order to prove the correctness of my implementation, I use the following userspace program to test whether the two different implementation generate exactly the same output for every number within the range of `u32` which is usually `unsigned` .
```
#include <stdlib.h>
#include <stdio.h>
#include <limits.h>

int generic_fls(unsigned int x)
{
	int r = 32;

	if (!x)
		return 0;
	if (!(x & 0xffff0000u)) {
		x <<= 16;
		r -= 16;
	}
	if (!(x & 0xff000000u)) {
		x <<= 8;
		r -= 8;
	}
	if (!(x & 0xf0000000u)) {
		x <<= 4;
		r -= 4;
	}
	if (!(x & 0xc0000000u)) {
		x <<= 2;
		r -= 2;
	}
	if (!(x & 0x80000000u)) {
		x <<= 1;
		r -= 1;
	}
	return r;
}

#define fls(x) generic_fls(x)

static unsigned highest_bit(unsigned flags)
{
	int bit = fls(flags);
	return bit ? 1 << (bit - 1) : 0;
}

static unsigned highest_bit_new(unsigned flags)
{
	int bit = fls(flags);
	return (1UL << bit) >> 1;
}

int main(void) {

    for (unsigned i = 0x00000000; i < 0x88888888; i++) {
	unsigned ans = highest_bit(i);
	unsigned ans_2 = highest_bit_new(i);
	if (ans != ans_2)
		printf("ans : %u, ans_2 : %u\n", ans, ans_2);
    }
    unsigned ans = highest_bit(0x88888888);
    unsigned ans_2 = highest_bit_new(0x88888888);
    if (ans != ans_2)
        printf("ans : %u, ans_2 : %u\n", ans, ans_2);

    return 0;
}
```
Compile the program and execute
```
$ gcc -o out main.c
$ ./out
```
Test Passed ! The correctness are proved.
### Performance
Change the user space program abit , only test a subset within the region of `unsigned` (so it won't take too much time for 1 single execution) . Using `perf stat` to observe the performance of the two different implementation
#### Branch version
```
#include <stdlib.h>
#include <stdio.h>
#include <limits.h>

int generic_fls(unsigned int x)
{
	int r = 32;

	if (!x)
		return 0;
	if (!(x & 0xffff0000u)) {
		x <<= 16;
		r -= 16;
	}
	if (!(x & 0xff000000u)) {
		x <<= 8;
		r -= 8;
	}
	if (!(x & 0xf0000000u)) {
		x <<= 4;
		r -= 4;
	}
	if (!(x & 0xc0000000u)) {
		x <<= 2;
		r -= 2;
	}
	if (!(x & 0x80000000u)) {
		x <<= 1;
		r -= 1;
	}
	return r;
}

#define fls(x) generic_fls(x)

static unsigned highest_bit(unsigned flags)
{
	int bit = fls(flags);
	return bit ? 1 << (bit - 1) : 0;
}

int main(void) {

    for (unsigned i = 0x70000000; i < 0x80000008; i++) {
	unsigned ans = highest_bit(i);
    }

    return 0;
}
```
Compile and use `perf` to observe the performance.
```
$ gcc -o out main.c
$ sudo perf stat --repeat 5 ./out

 Performance counter stats for './out' (5 runs):

            809.51 msec task-clock                       #    1.000 CPUs utilized               ( +-  2.03% )
                 2      context-switches                 #    2.471 /sec                        ( +- 25.50% )
                 0      cpu-migrations                   #    0.000 /sec                      
                50      page-faults                      #   61.766 /sec                        ( +-  0.40% )
      42,4302,2494      cycles                           #    5.241 GHz                         ( +-  0.04% )  (82.95%)
         1827,2293      stalled-cycles-frontend          #    0.43% frontend cycles idle        ( +-  0.71% )  (83.29%)
          158,1598      stalled-cycles-backend           #    0.04% backend cycles idle         ( +- 27.60% )  (83.45%)
     155,7262,2684      instructions                     #    3.67  insn per cycle            
                                                  #    0.00  stalled cycles per insn     ( +-  0.03% )  (83.46%)
      34,9005,2738      branches                         #    4.311 G/sec                       ( +-  0.04% )  (83.45%)
            5,5183      branch-misses                    #    0.00% of all branches             ( +-  7.62% )  (83.40%)

            0.8099 +- 0.0165 seconds time elapsed  ( +-  2.04% )
```
#### Branchless version
```
#include <stdlib.h>
#include <stdio.h>
#include <limits.h>

int generic_fls(unsigned int x)
{
	int r = 32;

	if (!x)
		return 0;
	if (!(x & 0xffff0000u)) {
		x <<= 16;
		r -= 16;
	}
	if (!(x & 0xff000000u)) {
		x <<= 8;
		r -= 8;
	}
	if (!(x & 0xf0000000u)) {
		x <<= 4;
		r -= 4;
	}
	if (!(x & 0xc0000000u)) {
		x <<= 2;
		r -= 2;
	}
	if (!(x & 0x80000000u)) {
		x <<= 1;
		r -= 1;
	}
	return r;
}

#define fls(x) generic_fls(x)

static unsigned highest_bit(unsigned flags)
{
	int bit = fls(flags);
	return (1UL << bit) >> 1;
}

int main(void) {

    for (unsigned i = 0x70000000; i < 0x80000008; i++) {
	unsigned ans = highest_bit(i);
    }

    return 0;
}
```
Compile and use `perf` to observe the performance.
```
$ gcc -o out main.c
$ sudo perf stat --repeat 5 ./out

 Performance counter stats for './out' (5 runs):

            726.41 msec task-clock                       #    1.000 CPUs utilized               ( +-  2.24% )
                 1      context-switches                 #    1.377 /sec                        ( +- 37.42% )
                 0      cpu-migrations                   #    0.000 /sec                      
                50      page-faults                      #   68.832 /sec                        ( +-  0.40% )
      37,8968,1629      cycles                           #    5.217 GHz                         ( +-  0.02% )  (83.25%)
          250,0461      stalled-cycles-frontend          #    0.07% frontend cycles idle        ( +-  2.88% )  (83.25%)
           91,6112      stalled-cycles-backend           #    0.02% backend cycles idle         ( +- 11.66% )  (83.26%)
     147,6344,7563      instructions                     #    3.90  insn per cycle            
                                                  #    0.00  stalled cycles per insn     ( +-  0.01% )  (83.25%)
      29,5408,1409      branches                         #    4.067 G/sec                       ( +-  0.01% )  (83.54%)
            4,8595      branch-misses                    #    0.00% of all branches             ( +-  2.67% )  (83.45%)

            0.7268 +- 0.0163 seconds time elapsed  ( +-  2.25% )
```

We can see significant improvements on cycles, stalled-cycles-frontend, especially branches and branch-misses.
The test runs on x86_64 AMD Ryzen 7 7700X 8-Core Processor , the operating system is Ubuntu 22.04.4 LTS .