### PR TITLE
scx: Add new enqueue flag to expose SCHED_CPUFREQ_IOWAIT

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -692,6 +692,9 @@ enum scx_enq_flags {
 	SCX_ENQ_WAKEUP		= ENQUEUE_WAKEUP,
 	SCX_ENQ_HEAD		= ENQUEUE_HEAD,
 
+	/* expose SCHED_CPUFREQ_IOWAIT flag as enum */
+	SCX_ENQ_FREQ_IOWAIT	= SCHED_CPUFREQ_IOWAIT,
+
 	/* high 32bits are SCX specific */
 
 	/*
@@ -1949,6 +1952,8 @@ static void enqueue_task_scx(struct rq *rq, struct task_struct *p, int enq_flags
 	rq->scx.nr_running++;
 	add_nr_running(rq, 1);
 
+	if (p->in_iowait)
+		enq_flags &= SCX_ENQ_FREQ_IOWAIT;
 	if (SCX_HAS_OP(runnable))
 		SCX_CALL_OP_TASK(SCX_KF_REST, runnable, p, enq_flags);
 


### PR DESCRIPTION
I want to try to replicate some of the handling of iowait boosting in sched_ext. One of the big advantages of sched_ext compared to [other approaches](https://lore.kernel.org/linux-pm/20240518113947.2127802-1-christian.loehle@arm.com/T/#t) is that it doesn't directly depend on modifying the `task_struct`. Instead, sched_ext schedulers can implement their own handling of iowait in a flexible manner. This borrows some of the ideas from [fair](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/sched/fair.c#n6768) scheduler.