### PR TITLE
SCX: Synchronize boot CPU's online state with SCX_RQ_ONLINE

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -5741,6 +5741,9 @@ void __init init_sched_ext_class(void)
 		BUG_ON(!zalloc_cpumask_var(&rq->scx.cpus_to_preempt, GFP_KERNEL));
 		BUG_ON(!zalloc_cpumask_var(&rq->scx.cpus_to_wait, GFP_KERNEL));
 		init_irq_work(&rq->scx.kick_cpus_irq_work, kick_cpus_irq_workfn);
+
+		if (cpu_online(cpu))
+			cpu_rq(cpu)->scx.flags |= SCX_RQ_ONLINE;
 	}
 
 	register_sysrq_key('S', &sysrq_sched_ext_reset_op);


### PR DESCRIPTION
We weren't synchronizing the boot CPU's online state with scx_rq's online state. This however was getting hidden through the RQ_ONOFF_TOPOLOGY update calls. 3a4476944ee2 ("scx: Replace scx_cpu_online percpu var with SCX_RQ_ONLINE flag") masked RQ_ONOFF_TOPOLOGY calls leaving the boot CPU marked offline from SCX's POV always forcing the CPU into local bypass mode, likely leading to reported interactivity problems on scx_rusty.

Fix it by synchronizing SCX_RQ_ONLINE with CPU's online states in init_sched_ext_class().