### PR TITLE
scx: Fix CPU online tracking

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -5741,9 +5741,6 @@ void __init init_sched_ext_class(void)
 		BUG_ON(!zalloc_cpumask_var(&rq->scx.cpus_to_preempt, GFP_KERNEL));
 		BUG_ON(!zalloc_cpumask_var(&rq->scx.cpus_to_wait, GFP_KERNEL));
 		init_irq_work(&rq->scx.kick_cpus_irq_work, kick_cpus_irq_workfn);
-
-		if (cpu_online(cpu))
-			cpu_rq(cpu)->scx.flags |= SCX_RQ_ONLINE;
 	}
 
 	register_sysrq_key('S', &sysrq_sched_ext_reset_op);
@@ -6965,3 +6962,17 @@ static int __init scx_init(void)
 	return 0;
 }
 __initcall(scx_init);
+
+
+static int __init scx_late_init(void)
+{
+	s32 cpu;
+
+	for_each_possible_cpu(cpu) {
+		if (cpu_online(cpu))
+			cpu_rq(cpu)->scx.flags |= SCX_RQ_ONLINE;
+	}
+
+	return 0;
+}
+late_initcall(scx_late_init);


### PR DESCRIPTION
Commit 10d167d8ab81 ("SCX: Synchronize boot CPU's online state with SCX_RQ_ONLINE") fixes the oversight that we're not synchronizing the boot CPU's online state with scx_rq's online state. It does this by adding a check in init_sched_ext_class() for whether a CPU is online, and setting the SCX_RQ_ONLINE flag in the rq if it is.

The online mask may not be initialized by the time init_sched_ext_class() is invoked, so let's add a late init function where we iterate over the possible CPUs and do this check there.