### PR TITLE
scx: Flip order of scx_rq_{de}activate()

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -9777,6 +9777,8 @@ int sched_cpu_activate(unsigned int cpu)
 		cpuset_cpu_active();
 	}
 
+	scx_rq_activate(rq);
+
 	/*
 	 * Put the rq online, if not already. This happens:
 	 *
@@ -9792,7 +9794,6 @@ int sched_cpu_activate(unsigned int cpu)
 		set_rq_online(rq);
 	}
 	rq_unlock_irqrestore(rq, &rf);
-	scx_rq_activate(rq);
 
 	return 0;
 }
@@ -9831,13 +9832,14 @@ int sched_cpu_deactivate(unsigned int cpu)
 	 */
 	synchronize_rcu();
 
-	scx_rq_deactivate(rq);
 	rq_lock_irqsave(rq, &rf);
 	if (rq->rd) {
 		BUG_ON(!cpumask_test_cpu(cpu, rq->rd->span));
 		set_rq_offline(rq);
 	}
 	rq_unlock_irqrestore(rq, &rf);
+
+	scx_rq_deactivate(rq);
 
 #ifdef CONFIG_SCHED_SMT
 	/*


### PR DESCRIPTION
Tejun pointed out that if we set or unset the hotplug online flag before we invoke the relevant hotplug callbacks, schedulers could get confused because they could begin receiving callbacks on a CPU before (or after) they're notified that a CPU is online (or offline).

Let's reverse the order to fix that.