### PR TITLE
scx: Pick an idle cpu when select runqueue with WF_EXEC

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -3107,8 +3107,10 @@ static int select_task_rq_scx(struct task_struct *p, int prev_cpu, int wake_flag
 	 * which can decide to preempt self to force it through the regular
 	 * scheduling path.
 	 */
-	if (unlikely(wake_flags & WF_EXEC))
-		return prev_cpu;
+	if (unlikely(wake_flags & WF_EXEC)) {
+		int idle_cpu = scx_pick_idle_cpu(p->cpus_ptr, SCX_PICK_IDLE_CORE);
+		return idle_cpu;
+	}
 
 	if (SCX_HAS_OP(select_cpu)) {
 		s32 cpu;


### PR DESCRIPTION
## Summary
If the caller of `select_task_rq_scx()` calls with `WF_EXEC`, it's a valuable balancing opportunity to perform task migration. Although runqueue can't dictate where the task is going to run, we can still take advantage of this good opportunity by selecting an idle core, rather than doing nothing.

## Note
This might be an over-concerned case for current implementation of sched_ext since there's no caller like `sched_exec()` under /kernel/sched/core.c which would call `select_task_rq()` with `WF_EXEC` . However it's still worth considering the changing and maybe add a proper caller with `WF_EXEC`.