### PR TITLE
scx: Fix error condition check in __scx_bpf_consume_task()

### DIFF
--- a/kernel/sched/ext.c
+++ b/kernel/sched/ext.c
@@ -6092,13 +6092,13 @@ __bpf_kfunc bool __scx_bpf_consume_task(unsigned long it, struct task_struct *p)
 	 */
 	dsq = READ_ONCE(p->scx.dsq);
 
+	if (unlikely(!dsq || dsq != kit_dsq))
+		return false;
+
 	if (unlikely(dsq->id == SCX_DSQ_LOCAL)) {
 		scx_ops_error("local DSQ not allowed");
 		return false;
 	}
-
-	if (unlikely(!dsq || dsq != kit_dsq))
-		return false;
 
 	if (!scx_kf_allowed(SCX_KF_DISPATCH))
 		return false;


### PR DESCRIPTION
__scx_bpf_consume_task() should test whether the task is still on the DSQ that's being iterated before erroring out if it's on a local DSQ. Otherwise, another racing consumer can move the task to a local DSQ triggering a spurious error. Relocate the error condition.